### PR TITLE
Update/remove call to deprecated hdmf functions

### DIFF
--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -29,7 +29,6 @@ from hdmf.backends.utils import (NamespaceToBuilderHelper,
 from hdmf.utils import (docval,
                         getargs,
                         popargs,
-                        call_docval_func,
                         get_docval,
                         get_data_shape)
 from hdmf.build import (Builder,
@@ -155,7 +154,7 @@ class ZarrIO(HDMFIO):
     def write(self, **kwargs):
         """Overwrite the write method to add support for caching the specification"""
         cache_spec = popargs('cache_spec', kwargs)
-        call_docval_func(super(ZarrIO, self).write, kwargs)
+        super(ZarrIO, self).write(**kwargs)
         if cache_spec:
             self.__cache_spec()
 
@@ -201,7 +200,7 @@ class ZarrIO(HDMFIO):
         # write_args['export_source'] = src_io.source  # pass export_source=src_io.source to write_builder
         ckwargs = kwargs.copy()
         ckwargs['write_args'] = write_args
-        call_docval_func(super().export, ckwargs)
+        super().export(**ckwargs)
         if cache_spec:
             self.__cache_spec()
 

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -67,7 +67,7 @@ class ZarrIO(HDMFIO):
              'doc': 'Zarr synchronizer to use for parallel I/O. If set to True a ProcessSynchronizer is used.',
              'default': None},
             {'name': 'object_codec_class', 'type': None,
-             'doc': 'Set the numcodec object codec class to be used to encode objects.' 
+             'doc': 'Set the numcodec object codec class to be used to encode objects.'
                     'Use numcodecs.pickles.Pickle by default.',
              'default': None})
     def __init__(self, **kwargs):

--- a/src/hdmf_zarr/nwb.py
+++ b/src/hdmf_zarr/nwb.py
@@ -2,9 +2,11 @@ from warnings import warn
 from .backend import ZarrIO
 import zarr
 
-from hdmf.utils import docval, popargs, call_docval_func
+from hdmf.utils import (docval,
+                        popargs)
 from hdmf.backends.io import HDMFIO
-from hdmf.build import BuildManager, TypeMap
+from hdmf.build import (BuildManager,
+                        TypeMap)
 
 try:
     from pynwb import get_manager, get_type_map
@@ -69,7 +71,7 @@ try:
         def export(self, **kwargs):
             nwbfile = popargs('nwbfile', kwargs)
             kwargs['container'] = nwbfile
-            call_docval_func(super().export, kwargs)
+            super().export(**kwargs)
 
 except ImportError:
     warn("PyNWB is not installed. Support for NWBZarrIO is disabled.")

--- a/src/hdmf_zarr/utils.py
+++ b/src/hdmf_zarr/utils.py
@@ -2,8 +2,9 @@ from zarr.hierarchy import Group
 import zarr
 import numcodecs
 import numpy as np
-from collections import (Iterable,
-                         deque)
+from collections import deque
+from collections.abc import Iterable
+
 import json
 import logging
 

--- a/src/hdmf_zarr/utils.py
+++ b/src/hdmf_zarr/utils.py
@@ -9,8 +9,7 @@ import logging
 
 from hdmf.data_utils import DataIO
 from hdmf.utils import (docval,
-                        getargs,
-                        docval_attr_name)
+                        getargs)
 
 from hdmf.spec import (SpecWriter,
                        SpecReader)

--- a/src/hdmf_zarr/utils.py
+++ b/src/hdmf_zarr/utils.py
@@ -10,7 +10,7 @@ import logging
 from hdmf.data_utils import DataIO
 from hdmf.utils import (docval,
                         getargs,
-                        call_docval_func)
+                        docval_attr_name)
 
 from hdmf.spec import (SpecWriter,
                        SpecReader)
@@ -133,7 +133,7 @@ class ZarrSpecReader(SpecReader):
     def __init__(self, **kwargs):
         self.__group, source = getargs('group', 'source', kwargs)
         super_kwargs = {'source': source}
-        call_docval_func(super(ZarrSpecReader, self).__init__, super_kwargs)
+        super(ZarrSpecReader, self).__init__(**super_kwargs)
 
     def __read(self, path):
         s = self.__group[path][0]
@@ -187,7 +187,12 @@ class ZarrDataIO(DataIO):
         # TODO Need to add error checks and warnings to ZarrDataIO to check for parameter collisions and add tests
         data, chunks, fill_value, compressor, filters, self.__link_data = getargs(
             'data', 'chunks', 'fillvalue', 'compressor', 'filters', 'link_data', kwargs)
-        call_docval_func(super(ZarrDataIO, self).__init__, kwargs)
+        # NOTE: dtype and shape of the DataIO base class are not yet supported by ZarrDataIO.
+        #       These parameters are used to create empty data to allocate the data but
+        #       leave the I/O to fill the data to the user.
+        super(ZarrDataIO, self).__init__(data=data,
+                                         dtype=None,
+                                         shape=None)
         if not isinstance(data, zarr.Array) and self.__link_data:
             self.__link_data = False
         self.__iosettings = dict()

--- a/tests/unit/test_io_convert.py
+++ b/tests/unit/test_io_convert.py
@@ -166,7 +166,8 @@ class TestDynamicTableContainerMixin():
     def setUpContainer(self):
         # TODO: The tables are names "root" because otherwise the Zarr backend does not determine the path correctly
         if self.TABLE_TYPE == 0:
-            table = DynamicTable(ROOT_NAME, 'an example table')
+            table = DynamicTable(name=ROOT_NAME,
+                                 description='an example table')
             table.add_column('foo', 'an int column')
             table.add_column('bar', 'a float column')
             table.add_column('qux', 'a boolean column')
@@ -175,7 +176,8 @@ class TestDynamicTableContainerMixin():
             table.add_row(foo=37, bar=38.0, qux=False, quux='b')
             return table
         elif self.TABLE_TYPE == 1:
-            table = DynamicTable(ROOT_NAME, 'an example table')
+            table = DynamicTable(name=ROOT_NAME,
+                                 description='an example table')
             table.add_column('foo', 'an int column')
             table.add_column('bar', 'a float column')
             table.add_column('baz', 'a string column')

--- a/tests/unit/test_io_convert.py
+++ b/tests/unit/test_io_convert.py
@@ -200,7 +200,10 @@ class TestCSRMatrixMixin():
         data = np.array([1, 2, 3, 4, 5, 6])
         indices = np.array([0, 2, 2, 0, 1, 2])
         indptr = np.array([0, 2, 3, 6])
-        return CSRMatrix(data, indices, indptr, (3, 3))
+        return CSRMatrix(data=data,
+                         indices=indices,
+                         indptr=indptr,
+                         shape=(3, 3))
 
 
 #########################################


### PR DESCRIPTION
* Replace calls to deprecated call_docval_func 
* Use keyword arguments for CSRMatrix and DynamicTable in tests to avoid DeprecationWarning due to the use of positional arguments
* Change deprecated import of ``collections.Iterable`` to ``collections.abc.Iterable``