### PR TITLE
Remove status warning on ZarrIO.__init__

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,12 @@
 .. image:: docs/source/figures/logo_hdmf_zarr.png
      :width: 400
-     
+
 hdmf-zarr
 =========
 
 The ``hdmf-zarr`` library implements a Zarr backend for HDMF as well as convenience classes for integration of Zarr with PyNWB to support writing of NWB files to Zarr.
 
-The Zarr backend is currently experimental and may still change. See the `overiew page <https://hdmf-zarr.readthedocs.io/en/latest/overview.html>`_ for an overview of the available features and known limitations of hdmf-zarr. 
+**Status:** The Zarr backend is **under development** and may still change. See the `overiew page <https://hdmf-zarr.readthedocs.io/en/latest/overview.html>`_ for an overview of the available features and known limitations of hdmf-zarr.
 
 
 Latest Release
@@ -36,7 +36,7 @@ CI / Health Status
 
 .. image:: https://github.com/hdmf-dev/hdmf-zarr/workflows/Deploy%20release/badge.svg
     :target: https://github.com/hdmf-dev/hdmf-zarr/actions/workflows/deploy_release.yml
-    
+
 .. image:: https://github.com/hdmf-dev/hdmf-zarr/workflows/black/badge.svg
     :target: https://github.com/hdmf-dev/hdmf-zarr/actions/workflows/black.yml
 

--- a/docs/gallery/plot_nwb_zarrio.py
+++ b/docs/gallery/plot_nwb_zarrio.py
@@ -23,8 +23,6 @@ tutorial.
 """
 # sphinx_gallery_thumbnail_path = 'figures/gallery_thumbnail_plot_nwbzarrio.png'
 # Ignore warnings about the development of the ZarrIO backend
-import warnings
-warnings.filterwarnings('ignore', '.*The ZarrIO backend is experimental*', )
 
 from datetime import datetime
 from dateutil.tz import tzlocal

--- a/docs/gallery/plot_zarr_dataset_io.py
+++ b/docs/gallery/plot_zarr_dataset_io.py
@@ -14,9 +14,6 @@ As a simple example, we first create a ``DynamicTable`` container
 to store some arbitrary data columns.
 """
 # sphinx_gallery_thumbnail_path = 'figures/gallery_thumbnail_plot_zarr_dataset_io.png'
-# Ignore warnings about the development of the ZarrIO backend
-import warnings
-warnings.filterwarnings('ignore', '.*The ZarrIO backend is experimental*', )
 
 # Import DynamicTable and get the ROOT_NAME
 from hdmf.common.table import DynamicTable, VectorData

--- a/docs/gallery/plot_zarr_io.py
+++ b/docs/gallery/plot_zarr_io.py
@@ -24,9 +24,6 @@ describing basic user data.
    of a file does not appear in the path to locate it.
 """
 # sphinx_gallery_thumbnail_path = 'figures/gallery_thumbnail_plot_zarr_io.png'
-# Ignore warnings about the development of the ZarrIO backend
-import warnings
-warnings.filterwarnings('ignore', '.*The ZarrIO backend is experimental*', )
 
 # Import DynamicTable and get the ROOT_NAME
 from hdmf.common.table import DynamicTable

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,9 @@ Welcome to hdmf-zarr's documentation!
 convenience classes for integration of Zarr with `PyNWB <https://pynwb.readthedocs.io>`_ to
 support writing of NWB files to `Zarr <https://zarr.readthedocs.io/en/stable/>`_.
 
+**Status:** The Zarr backend is **under development** and may still change. See the
+:ref:`sec-overview` section for a description of available features and known limitations of hdmf-zarr.
+
 Citing hdmf-zarr
 ^^^^^^^^^^^^^^^^
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -1,3 +1,5 @@
+.. _sec-overview:
+
 Overview
 ========
 

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -87,9 +87,6 @@ class ZarrIO(HDMFIO):
         # Codec class to be used. Alternates, e.g., =numcodecs.JSON
         self.__codec_cls = numcodecs.pickles.Pickle if object_codec_class is None else object_codec_class
         super().__init__(manager, source=path)
-        warn_msg = ("The ZarrIO backend is experimental. It is under active development. "
-                    "The ZarrIO backend may change any time and backward compatibility is not guaranteed.")
-        warnings.warn(warn_msg)
 
     @property
     def path(self):


### PR DESCRIPTION
This PR:
* Remove the warning message about ZarrIO being experimental as it a bit too intrusive 
* Add status message to README and docs
* Remove the warnings filter from the tutorials as it is no longer needed