### PR TITLE
Remove ZarrIO development status warning

### DIFF
--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -114,9 +114,6 @@ class ZarrIO(HDMFIO):
         if isinstance(self.__path, SUPPORTED_ZARR_STORES):
             source_path = self.__path.path
         super().__init__(manager, source=source_path)
-        warn_msg = ("The ZarrIO backend is experimental. It is under active development. "
-                    "The ZarrIO backend may change any time and backward compatibility is not guaranteed.")
-        warnings.warn(warn_msg)
 
     @property
     def file(self):


### PR DESCRIPTION
Most likely due to an error during the resolution of merge conflicts between branches, the status warning message in ZarrIO that was removed in https://github.com/hdmf-dev/hdmf-zarr/pull/67 was added back in when https://github.com/hdmf-dev/hdmf-zarr/pull/62 was merged. This PR corrects this error by removing the warning. 