### PR TITLE
Fix reading dtype from zarr dataset

### DIFF
--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1104,7 +1104,9 @@ class ZarrIO(HDMFIO):
             zarr_dtype = zarr_obj.attrs['zarr_dtype']
         elif hasattr(zarr_obj, 'dtype'):   # Fallback for invalid files that are mssing zarr_type
             zarr_dtype = zarr_obj.dtype
-            warnings.warn("Inferred dtype from zarr type. Dataset missing zarr_dtype: " + str(name) + "   " + str(zarr_obj)) 
+            warnings.warn(
+                "Inferred dtype from zarr type. Dataset missing zarr_dtype: " + str(name) + "   " + str(zarr_obj)
+            )
         else:
             raise ValueError("Dataset missing zarr_dtype: " + str(name) + "   " + str(zarr_obj))
 

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1100,7 +1100,7 @@ class ZarrIO(HDMFIO):
         if ret is not None:
             return ret
 
-        if 'zarr_dtype' not in zarr_obj.attrs:
+        if 'zarr_dtype' in zarr_obj.attrs:
             zarr_dtype = zarr_obj.attrs['zarr_dtype']
         elif hasattr(zarr_obj, 'dtype'):   # Fallback for invalid files that are mssing zarr_type
             zarr_dtype = zarr_obj.dtype

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1099,11 +1099,16 @@ class ZarrIO(HDMFIO):
         if ret is not None:
             return ret
 
-        if 'zarr_dtype' not in zarr_obj.attrs:
-            raise ValueError("Dataset missing zarr_dtype: " + str(name) + "   " + str(zarr_obj))
+        if hasattr(zarr_obj, 'dtype'):
+            zarr_dtype = zarr_obj.dtype
+        else:
+            if 'zarr_dtype' in zarr_obj.attrs:
+                zarr_dtype = zarr_obj.attrs['zarr_dtype']
+            else:
+                raise ValueError("Dataset missing zarr_dtype: " + str(name) + "   " + str(zarr_obj))
 
         kwargs = {"attributes": self.__read_attrs(zarr_obj),
-                  "dtype": zarr_obj.attrs['zarr_dtype'],
+                  "dtype": zarr_dtype,
                   "maxshape": zarr_obj.shape,
                   "chunks": not (zarr_obj.shape == zarr_obj.chunks),
                   "source": self.source}

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -670,7 +670,7 @@ class ZarrIO(HDMFIO):
                 io_settings['dtype'] = cls.__dtypes.get(io_settings['dtype'])
         try:
             dset = parent.create_dataset(name, **io_settings)
-            dset.attrs['zarr_dtype'] = io_settings['dtype']
+            dset.attrs['zarr_dtype'] = np.dtype(io_settings['dtype']).str
         except Exception as exc:
             raise Exception("Could not create dataset %s in %s" % (name, parent.name)) from exc
         return dset


### PR DESCRIPTION
Hi guys, 

I'm experimenting now with writing to Zarr using a custom DataChunkIterator from [neuroconv](https://github.com/catalystneuro/neuroconv/blob/main/src/neuroconv/tools/spikeinterface/spikeinterfacerecordingdatachunkiterator.py#L8) bassed to the `ZarrDataIO`.

Everything works fine, but upon reading the file, I get that the `zarr_type` is not found in the attirbutes. However, this can be inferred from the `dtype` of the `zarr.Dataset`. 
Not sure this is the most elegant solution and I didn't have time to dig in and find a better one, but it works in my case :)