### PR TITLE
add can_read classmethod to ZarrIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Minor enhancements
 * Updated handling of references on read to simplify future integration of file-based Zarr 
   stores (e.g., ZipStore or database stores) @oruebel [#62](https://github.com/hdmf-dev/hdmf-zarr/pull/62)
+* Added can_read classmethod to ZarrIO. @bendichter [#97](https://github.com/hdmf-dev/hdmf-zarr/pull/97)
 
 ### Test suite enhancements
 * Modularized unit tests to simplify running tests for multiple Zarr storage backends

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -75,8 +75,8 @@ Tuple listing all Zarr storage backends supported by ZarrIO
 
 class ZarrIO(HDMFIO):
 
-    @classmethod
-    def can_read(cls, path):
+    @staticmethod
+    def can_read(path):
         try:
             zarr.open(path, mode="r")
             return True

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -75,6 +75,14 @@ Tuple listing all Zarr storage backends supported by ZarrIO
 
 class ZarrIO(HDMFIO):
 
+    @classmethod
+    def can_read(cls, path):
+        try:
+            zarr.open(path, mode="r")
+            return True
+        except Exception:
+            return False
+
     @docval({'name': 'path',
              'type': (str, *SUPPORTED_ZARR_STORES),
              'doc': 'the path to the Zarr file or a supported Zarr store'},

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -299,7 +299,6 @@ class BaseTestZarrWriter(BaseZarrWriterTestCase):
     def test_read_int(self):
         test_data = np.arange(100, 200, 10).reshape(5, 2)
         self.test_write_int(test_data=test_data)
-
         dataset = self.read_test_dataset()['data'][:]
         self.assertTrue(np.all(test_data == dataset))
 

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -170,6 +170,9 @@ class BaseTestZarrWriter(BaseZarrWriterTestCase):
                                          'ref_dataset': dataset_ref})
         return builder
 
+    def test_cannot_read(self):
+        assert not ZarrIO.can_read("incorrect_path")
+
     def read_test_dataset(self):
         reader = ZarrIO(self.store, manager=self.manager, mode='r')
         self.root = reader.read_builder()
@@ -209,6 +212,7 @@ class BaseTestZarrWriter(BaseZarrWriterTestCase):
         writer = ZarrIO(self.store, manager=self.manager, mode='a')
         writer.write_builder(self.builder)
         writer.close()
+        assert ZarrIO.can_read(self.store)
 
     def test_write_compound(self, test_data=None):
         """
@@ -295,6 +299,7 @@ class BaseTestZarrWriter(BaseZarrWriterTestCase):
     def test_read_int(self):
         test_data = np.arange(100, 200, 10).reshape(5, 2)
         self.test_write_int(test_data=test_data)
+
         dataset = self.read_test_dataset()['data'][:]
         self.assertTrue(np.all(test_data == dataset))
 


### PR DESCRIPTION
add test for new method

## Motivation

https://github.com/NeurodataWithoutBorders/pynwb/pull/859#issuecomment-477254858

## How to test the behavior?
```
ZarrIO.can_read(path)
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
