### PR TITLE
Add OtherIO.can_read method to tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@
 ### Minor enhancements
 * Updated handling of references on read to simplify future integration of file-based Zarr 
   stores (e.g., ZipStore or database stores) @oruebel [#62](https://github.com/hdmf-dev/hdmf-zarr/pull/62)
-* Added can_read classmethod to ZarrIO. @bendichter [#97](https://github.com/hdmf-dev/hdmf-zarr/pull/97)
+* Added ``can_read`` classmethod to ``ZarrIO``. @bendichter [#97](https://github.com/hdmf-dev/hdmf-zarr/pull/97)
 
 ### Test suite enhancements
 * Modularized unit tests to simplify running tests for multiple Zarr storage backends
   @oruebel [#62](https://github.com/hdmf-dev/hdmf-zarr/pull/62)
+* Updated tests to handle upcoming changes to ``HDMFIO``. @rly [#102](https://github.com/hdmf-dev/hdmf-zarr/pull/102)
 
 ### Docs
 * Added developer documentation on how to integrate new storage backends with ZarrIO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,21 @@
 
 ### New Features
 * Added support, tests, and docs for using ``DirectoryStore``, ``TempStore``, and
-  ``NestedDirectoryStore`` Zarr storage backends with ``ZarrIO`` and ``NWBZarrIO`` 
+  ``NestedDirectoryStore`` Zarr storage backends with ``ZarrIO`` and ``NWBZarrIO``. 
   @oruebel [#62](https://github.com/hdmf-dev/hdmf-zarr/pull/62)
 
 ### Minor enhancements
 * Updated handling of references on read to simplify future integration of file-based Zarr 
-  stores (e.g., ZipStore or database stores) @oruebel [#62](https://github.com/hdmf-dev/hdmf-zarr/pull/62)
+  stores (e.g., ZipStore or database stores). @oruebel [#62](https://github.com/hdmf-dev/hdmf-zarr/pull/62)
 * Added ``can_read`` classmethod to ``ZarrIO``. @bendichter [#97](https://github.com/hdmf-dev/hdmf-zarr/pull/97)
 
 ### Test suite enhancements
-* Modularized unit tests to simplify running tests for multiple Zarr storage backends
+* Modularized unit tests to simplify running tests for multiple Zarr storage backends.
   @oruebel [#62](https://github.com/hdmf-dev/hdmf-zarr/pull/62)
 * Updated tests to handle upcoming changes to ``HDMFIO``. @rly [#102](https://github.com/hdmf-dev/hdmf-zarr/pull/102)
 
 ### Docs
-* Added developer documentation on how to integrate new storage backends with ZarrIO
+* Added developer documentation on how to integrate new storage backends with ZarrIO. @oruebel
   [#62](https://github.com/hdmf-dev/hdmf-zarr/pull/62)
 
 ### API Changes

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -1434,6 +1434,10 @@ class BaseTestExportZarrToZarr(BaseZarrWriterTestCase):
 
         class OtherIO(HDMFIO):
 
+            @staticmethod
+            def can_read(path):
+                pass
+
             def read_builder(self):
                 pass
 


### PR DESCRIPTION
## Motivation

Adding `OtherIO.can_read` is necessary once https://github.com/hdmf-dev/hdmf/pull/875 is merged.


## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
