### PR TITLE
Add OtherIO.can_read method to tests part 2

### DIFF
--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -1470,6 +1470,10 @@ class BaseTestExportZarrToZarr(BaseZarrWriterTestCase):
             def __init__(self, manager):
                 super().__init__(manager=manager)
 
+            @staticmethod
+            def can_read(path):
+                pass
+
             def read_builder(self):
                 pass
 


### PR DESCRIPTION
## Motivation

Follow up to #102. Needed to work with https://github.com/hdmf-dev/hdmf/pull/875