### PR TITLE
Update deploy_release.yml

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -28,11 +28,11 @@ jobs:
 
       - name: Run tox tests
         run: |
-          tox -e py310-upgraded
+          tox -e py311-upgraded
 
       - name: Build wheel and source distribution
         run: |
-          tox -e build-py310-upgraded
+          tox -e build-py311-upgraded
           ls -1 dist
 
       - name: Test installation from a wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF-ZARR Changelog
 
+## 0.3.1 (Upcoming)
+
+### Bug fixes
+* Fixed error in deploy workflow. @mavaylon1 [#109](https://github.com/hdmf-dev/hdmf-zarr/pull/109)
+
+
 ## 0.3.0 (July 21, 2023)
 
 ### New Features


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.
When deploy_release was updated for 3.11, not everything was shifted to 3.11 in the workflow. This needs to be updated for the workflow to pass.

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```
Run the workflow.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
