### PR TITLE
numpy degrade for python 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 * Fixed error in deploy workflow. @mavaylon1 [#109](https://github.com/hdmf-dev/hdmf-zarr/pull/109)
-* fixed build error for ReadtheDocs. @mavaylon1 [#115](https://github.com/hdmf-dev/hdmf-zarr/pull/115)
+* Fixed build error for ReadtheDocs by degrading numpy for python 3.7 support. @mavaylon1 [#115](https://github.com/hdmf-dev/hdmf-zarr/pull/115)
 
 
 ## 0.3.0 (July 21, 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 * Fixed error in deploy workflow. @mavaylon1 [#109](https://github.com/hdmf-dev/hdmf-zarr/pull/109)
+* fixed build error for ReadtheDocs. @mavaylon1 [#115](https://github.com/hdmf-dev/hdmf-zarr/pull/115)
 
 
 ## 0.3.0 (July 21, 2023)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@
 hdmf==3.5.4
 zarr==2.11.0
 pynwb==2.3.2
-numpy==1.21
+numpy==1.21; python_version<3.8
+numpy>=1.22; python_version>=3.8
 numcodecs==0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ zarr==2.11.0
 pynwb==2.3.2
 numpy==1.21; python_version < "3.8"
 numpy>=1.22; python_version >= "3.8"
-numcodecs==0.11.0
+numcodecs==0.10.2; python_version < "3.8"
+numcodecs==0.11.0; python_version >= "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 hdmf==3.5.4
 zarr==2.11.0
 pynwb==2.3.2
-numpy==1.23.5
+numpy==1.21
 numcodecs==0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ hdmf==3.5.4
 zarr==2.11.0
 pynwb==2.3.2
 numpy==1.21; python_version < "3.8"
-numpy>=1.22; python_version >= "3.8"
+numpy==1.23; python_version >= "3.8"
 numcodecs==0.10.2; python_version < "3.8"
 numcodecs==0.11.0; python_version >= "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 hdmf==3.5.4
 zarr==2.11.0
 pynwb==2.3.2
-numpy==1.21; python_version<3.8
-numpy>=1.22; python_version>=3.8
+numpy==1.21; python_version < "3.8"
+numpy>=1.22; python_version >= "3.8"
 numcodecs==0.11.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ print('found these packages:', pkgs)
 reqs = [
     'hdmf==3.5.4',  # temporary
     'zarr>=2.11.0',
-    'numpy<1.22; python_version=="3.7"',
+    'numpy<1.22; python_version < "3.8"',
+    'numpy>=1.22; python_version >= "3.8",
     'numcodecs>=0.9.1',
     'numcodecs==0.10.2; python_version < "3.8"',
     'numcodecs==0.11.0; python_version >= "3.8"',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ print('found these packages:', pkgs)
 reqs = [
     'hdmf==3.5.4',  # temporary
     'zarr>=2.11.0',
-    'numpy<1.22; python_version>"3.7"',
+    'numpy<1.22; python_version=="3.7"',
     'numcodecs>=0.9.1',
     'pynwb>=2.3.2',
     'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ reqs = [
     'hdmf==3.5.4',  # temporary
     'zarr>=2.11.0',
     'numpy<1.22; python_version < "3.8"',
-    'numpy>=1.22; python_version >= "3.8",
+    'numpy>=1.22; python_version >= "3.8"',
     'numcodecs>=0.9.1',
     'numcodecs==0.10.2; python_version < "3.8"',
     'numcodecs==0.11.0; python_version >= "3.8"',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ print('found these packages:', pkgs)
 reqs = [
     'hdmf==3.5.4',  # temporary
     'zarr>=2.11.0',
-    'numpy>=1.22, <1.24; python_version>"3.7"',
+    'numpy<1.22; python_version>"3.7"',
     'numcodecs>=0.9.1',
     'pynwb>=2.3.2',
     'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ reqs = [
     'zarr>=2.11.0',
     'numpy<1.22; python_version=="3.7"',
     'numcodecs>=0.9.1',
+    'numcodecs==0.10.2; python_version < "3.8"',
+    'numcodecs==0.11.0; python_version >= "3.8"',
     'pynwb>=2.3.2',
     'setuptools',
 ]


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.
Update python that supports 3.7. This is meant to address the fact that the Read the Docs for HDMF-Zarr does not build.

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```
Run the tests and check read the docs build
## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
