### PR TITLE
Fix #127 update paralle write test to set table ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Enhanced ZarrIO to resolve object references lazily on read similar to HDMF's `HDF5IO` backend. @mavaylon1 [#120](https://github.com/hdmf-dev/hdmf-zarr/pull/120)
 
 ### New Features
-* Added parallel write support for the ``ZarrIO`` for datasets wrapped with ``GenericDataChunkIterator``. @CodyCBakerPhD [#118](https://github.com/hdmf-dev/hdmf-zarr/pull/118)
+* Added parallel write support for the ``ZarrIO`` for datasets wrapped with ``GenericDataChunkIterator``. @CodyCBakerPhD [#118](https://github.com/hdmf-dev/hdmf-zarr/pull/118) @oruebel [#128](https://github.com/hdmf-dev/hdmf-zarr/pull/128)
 
 ### Dependencies
 * Updated HDMF and PyNWB version to the most recent release @mavaylon1 [#120](https://github.com/hdmf-dev/hdmf-zarr/pull/120)

--- a/tests/unit/test_parallel_write.py
+++ b/tests/unit/test_parallel_write.py
@@ -189,7 +189,12 @@ def test_simple_tqdm(tmpdir):
                     display_progress=True,
                 )
             )
-            dynamic_table = DynamicTable(name="TestTable", description="", columns=[column])
+            dynamic_table = DynamicTable(
+                name="TestTable",
+                description="",
+                columns=[column],
+                id=list(range(3))  # must provide id's when all columns are iterators
+            )
             io.write(container=dynamic_table, number_of_jobs=number_of_jobs)
 
     assert expected_desc in tqdm_out.getvalue()
@@ -222,7 +227,10 @@ def test_compound_tqdm(tmpdir):
                 )
             )
             dynamic_table = DynamicTable(
-                name="TestTable", description="", columns=[pickleable_column, not_pickleable_column]
+                name="TestTable",
+                description="",
+                columns=[pickleable_column, not_pickleable_column],
+                id=list(range(3))  # must provide id's when all columns are iterators
             )
             io.write(container=dynamic_table, number_of_jobs=number_of_jobs)
 


### PR DESCRIPTION
## Motivation

Fix #127 update parallel write test to set table ids when all columns are iterators

## How to test the behavior?

Run `pytest` on the `dev` branch using HDMF on `dev`

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
