### PR TITLE
Write references in compound datasets at the end

### DIFF
--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1018,11 +1018,20 @@ class ZarrIO(HDMFIO):
                                               **options['io_settings'])
                 self._written_builders.set_written(builder)  # record that the builder has been written
                 dset.attrs['zarr_dtype'] = type_str
+                new_items = []
                 for j, item in enumerate(data):
                     new_item = list(item)
                     for i in refs:
                         new_item[i] = self.__get_ref(item[i], export_source=export_source)
-                    dset[j] = new_item
+                    new_items.append(tuple(new_item))
+                    # dset[j] = new_item
+
+                generated_dtype = []
+                for item in builder.dtype:
+                    if item['dtype'] == type('string'):
+                        item['dtype'] = 'U25'
+                    generated_dtype.append((item['name'], item['dtype']))
+                dset[...] = np.array(new_items, dtype=generated_dtype)
             else:
                 # write a compound datatype
                 dset = self.__list_fill__(parent, name, data, options)

--- a/src/hdmf_zarr/zarr_utils.py
+++ b/src/hdmf_zarr/zarr_utils.py
@@ -151,7 +151,8 @@ class AbstractZarrTableDataset(DatasetOfReferences):
         return self.__dtype
 
     def __getitem__(self, arg):
-        rows = copy(super().__getitem__(arg))
+        rows = list(copy(super().__getitem__(arg)))
+        # breakpoint()
         if np.issubdtype(type(arg), np.integer):
             self.__swap_refs(rows)
         else:

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -426,7 +426,7 @@ class BaseTestZarrWriter(BaseZarrWriterTestCase):
         builder = self.createReferenceBuilder()['ref_dataset']
         read_builder = self.root['ref_dataset']
         # Load the linked arrays and confirm we get the same data as we had in the original builder
-        breakpoint()
+        # breakpoint()
         # for i, v in enumerate(read_builder['data']):
         #     self.assertTrue(np.all(builder['data'][i]['builder']['data'] == v['data'][:]))
 
@@ -435,24 +435,16 @@ class BaseTestZarrWriter(BaseZarrWriterTestCase):
         self.read()
         builder = self.createReferenceCompoundBuilder()['ref_dataset']
         read_builder = self.root['ref_dataset']
-        read_builder['data'][0]
-        #Load the elements of each entry in the compound dataset and compare the index, string, and referenced array
+
+        # ensure the array was written as a compound array
+        ref_dtype = np.dtype([('id', '<i4'), ('name', '<U'), ('reference', 'O')])
+        self.assertEqual(read_builder.data.dataset.dtype, ref_dtype)
         breakpoint()
+        # Load the elements of each entry in the compound dataset and compar the index, string, and referenced array
         # for i, v in enumerate(read_builder['data']):
-        #     # self.assertEqual(v[0], builder['data'][i][0])  # Compare index value from compound tuple
+        #     self.assertEqual(v[0], builder['data'][i][0])  # Compare index value from compound tuple
         #     self.assertEqual(v[1], builder['data'][i][1])  # Compare string value from compound tuple
-        # self.assertTrue(np.all(v[2]['data'][:] == builder['data'][i][2]['builder']['data'][:]))  # Compare ref array
-
-        # self.assertEqual(read_builder['data'].dataset[0][0], builder['data'][0][0])
-        # self.assertEqual(read_builder['data'].dataset[0][0], builder['data'][1][0])
-        # self.assertEqual(read_builder['data'].dataset[0][1], 'dataset_1')
-        # self.assertEqual(read_builder['data'].dataset[1][1], 'dataset_2')
-        # self.assertEqual(read_builder['data'].dataset[0][1], '/dataset_1')
-        # self.assertEqual(read_builder['data'].dataset[1][1], '/dataset_2')
-
-            # self.assertEqual(v[1], builder['data'][i][1])  # Compare string value from compound tuple
-            # self.assertTrue(np.all(v[2]['data'][:] == builder['data'][i][2]['builder']['data'][:]))  # Compare ref array
-
+        #     self.assertTrue(np.all(v[2]['data'][:] == builder['data'][i][2]['builder']['data'][:]))  # Compare ref array
 
     def test_read_reference_compound_buf(self):
         data_1 = np.arange(100, 200, 10).reshape(2, 5)

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -426,20 +426,33 @@ class BaseTestZarrWriter(BaseZarrWriterTestCase):
         builder = self.createReferenceBuilder()['ref_dataset']
         read_builder = self.root['ref_dataset']
         # Load the linked arrays and confirm we get the same data as we had in the original builder
-        for i, v in enumerate(read_builder['data']):
-            self.assertTrue(np.all(builder['data'][i]['builder']['data'] == v['data'][:]))
+        breakpoint()
+        # for i, v in enumerate(read_builder['data']):
+        #     self.assertTrue(np.all(builder['data'][i]['builder']['data'] == v['data'][:]))
 
     def test_read_reference_compound(self):
         self.test_write_reference_compound()
         self.read()
         builder = self.createReferenceCompoundBuilder()['ref_dataset']
         read_builder = self.root['ref_dataset']
-        # Load the elements of each entry in the compound dataset and compar the index, string, and referenced array
-        for i, v in enumerate(read_builder['data']):
-            self.assertEqual(v[0], builder['data'][i][0])  # Compare index value from compound tuple
-            self.assertEqual(v[1], builder['data'][i][1])  # Compare string value from compound tuple
-            self.assertTrue(np.all(v[2]['data'][:] == builder['data'][i][2]['builder']['data'][:]))  # Compare ref array
-        # print(read_builder)
+        read_builder['data'][0]
+        #Load the elements of each entry in the compound dataset and compare the index, string, and referenced array
+        breakpoint()
+        # for i, v in enumerate(read_builder['data']):
+        #     # self.assertEqual(v[0], builder['data'][i][0])  # Compare index value from compound tuple
+        #     self.assertEqual(v[1], builder['data'][i][1])  # Compare string value from compound tuple
+        # self.assertTrue(np.all(v[2]['data'][:] == builder['data'][i][2]['builder']['data'][:]))  # Compare ref array
+
+        # self.assertEqual(read_builder['data'].dataset[0][0], builder['data'][0][0])
+        # self.assertEqual(read_builder['data'].dataset[0][0], builder['data'][1][0])
+        # self.assertEqual(read_builder['data'].dataset[0][1], 'dataset_1')
+        # self.assertEqual(read_builder['data'].dataset[1][1], 'dataset_2')
+        # self.assertEqual(read_builder['data'].dataset[0][1], '/dataset_1')
+        # self.assertEqual(read_builder['data'].dataset[1][1], '/dataset_2')
+
+            # self.assertEqual(v[1], builder['data'][i][1])  # Compare string value from compound tuple
+            # self.assertTrue(np.all(v[2]['data'][:] == builder['data'][i][2]['builder']['data'][:]))  # Compare ref array
+
 
     def test_read_reference_compound_buf(self):
         data_1 = np.arange(100, 200, 10).reshape(2, 5)


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.
Fix #144 

Notes:
The fix at face value is the following:
```
for j, item in enumerate(data):
        new_item = list(item)
        for i in refs:
             new_item[i] = self.__get_ref(item[i], export_source=export_source)
        new_items.append(tuple(new_item))
        
        generated_dtype = []
        for item in builder.dtype:
              if item['dtype'] == type('string'):
                  item['dtype'] = 'U25'
              generated_dtype.append((item['name'], item['dtype']))

 dset[...] = np.array(new_items, dtype=generated_dtype)
```

TLDR: We want to write outside of the the loop. What does this lead to?

To keep our compound dataset in its original form (i.e not expanded) we can use a structured array an pull the dtypes from the builder. However, it is required that the "data" in the array be in tuples and not lists (I believe it can also be in np.arrays but I have not tested this). 

Having these as tuples makes things a bit hard when retrieving data on read. For example, in the test `test_read_reference_compound`
```
def test_read_reference_compound(self):
        self.test_write_reference_compound()
        self.read()
        builder = self.createReferenceCompoundBuilder()['ref_dataset']
        read_builder = self.root['ref_dataset']
```
If I try to run `read_builder['data'][0]` I will get an error that `*** TypeError: 'tuple' object does not support item assignment`. Digging deeper it is because our `get_item` swaps/will reassign values in the tuple. This is not allowed because it is a tuple. Now I can convert that to a list on `_get_item_` and that does work. However, it is a little hacky. It also doesn't cover when my index is ":" vs a single integer. 

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
