### PR TITLE
Fix bug when exporting HDF5 datasets with unlimited dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Enhancements
 * Enhanced `ZarrIO` and `ZarrDataIO` to infer io settings (e.g., chunking and compression) from HDF5 datasets to preserve storage settings on export if possible @oruebel [#153](https://github.com/hdmf-dev/hdmf-zarr/pull/153)
 
+### Bug Fixes
+* Fixed bug when converting HDF5 datasets with unlimited dimensions @oruebel [#155](https://github.com/hdmf-dev/hdmf-zarr/pull/155)
+
 ## 0.5.0 (December 8, 2023)
 
 ### Enhancements

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1193,7 +1193,13 @@ class ZarrIO(HDMFIO):
             data_shape = io_settings.pop('shape')
         # If we have a numeric numpy array then use its shape
         elif isinstance(dtype, np.dtype) and np.issubdtype(dtype, np.number) or dtype == np.bool_:
-            data_shape = get_data_shape(data)
+            # HDMF's get_data_shape may return the maxshape of an HDF5 dataset which can include None values
+            # which Zarr does not allow for dataset shape. Check for the shape attribute first before falling
+            # back on get_data_shape
+            if hasattr(data, 'shape') and data.shape is not None:
+                data_shape = data.shape  
+            else:
+                data_shape = get_data_shape(data)
         # Deal with object dtype
         elif isinstance(dtype, np.dtype):
             data = data[:]  # load the data in case we come from HDF5 or another on-disk data source we don't know

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1174,9 +1174,8 @@ class ZarrIO(HDMFIO):
         io_settings = dict()
         if options is not None:
             dtype = options.get('dtype')
-            io_settings = options.get('io_settings')
-            if io_settings is None:
-                io_settings = dict()
+            if options.get('io_settings') is not None:
+                io_settings = options.get('io_settings')
         # Determine the dtype
         if not isinstance(dtype, type):
             try:

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1191,15 +1191,16 @@ class ZarrIO(HDMFIO):
         # Determine the shape and update the dtype if necessary when dtype==object
         if 'shape' in io_settings:  # Use the shape set by the user
             data_shape = io_settings.pop('shape')
-        # If we have a numeric numpy array then use its shape
+        # If we have a numeric numpy-like array (e.g., numpy.array or h5py.Dataset) then use its shape
         elif isinstance(dtype, np.dtype) and np.issubdtype(dtype, np.number) or dtype == np.bool_:
             # HDMF's get_data_shape may return the maxshape of an HDF5 dataset which can include None values
             # which Zarr does not allow for dataset shape. Check for the shape attribute first before falling
             # back on get_data_shape
             if hasattr(data, 'shape') and data.shape is not None:
                 data_shape = data.shape  
-            else:
-                data_shape = get_data_shape(data)
+            # This is a fall-back just in case. However this should not happen for standard numpy and h5py arrays 
+            else: # pragma: no cover
+                data_shape = get_data_shape(data) # pragma: no cover
         # Deal with object dtype
         elif isinstance(dtype, np.dtype):
             data = data[:]  # load the data in case we come from HDF5 or another on-disk data source we don't know

--- a/tests/unit/test_io_convert.py
+++ b/tests/unit/test_io_convert.py
@@ -868,6 +868,12 @@ class TestHDF5toZarrWithFilters(TestCase):
         """For a container created by __roundtrip_data return the data array"""
         return foo_container.buckets['bucket1'].foos['foo1'].my_data
 
+    def test_maxshape(self):
+        """test when maxshape is set for the dataset"""
+        data = H5DataIO(data=list(range(5)), maxshape=(None,))
+        self.__roundtrip_data(data=data)
+        self.assertContainerEqual(self.out_container, self.read_container, ignore_hdmf_attrs=True)
+
     def test_nofilters(self):
         """basic test that export without any options specified is working as expected"""
         data = list(range(5))


### PR DESCRIPTION
## Motivation

Fix #154 

When an HDF5 file contains datasets with unlimited dimensions, use of the `hdmf.utils.get_data_shape` method yields the wrong data shape because the functions looks at `maxshape` first. This leads to an error on export because Zarr cannot create a dataset with undefined dimensions. 

## How to test the behavior?

See #154

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
