### PR TITLE
Add NWB file convert unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 * Fixed bug when converting HDF5 datasets with unlimited dimensions @oruebel [#155](https://github.com/hdmf-dev/hdmf-zarr/pull/155)
+* Fixed bug resolving bytes dtype when exporting from Zarr to Zarr @oruebel [#161](https://github.com/hdmf-dev/hdmf-zarr/pull/161)
 * Adjust gallery tests to not fail on deprecation warnings from pandas. @rly [#157](https://github.com/hdmf-dev/hdmf-zarr/pull/157)
 
 ## 0.5.0 (December 8, 2023)

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1137,6 +1137,7 @@ class ZarrIO(HDMFIO):
         "utf8": str,
         "utf-8": str,
         "ascii": bytes,
+        "bytes":  bytes,
         "str": str,
         "isodatetime": str,
         "string_": bytes,
@@ -1193,7 +1194,9 @@ class ZarrIO(HDMFIO):
     @classmethod
     def get_type(cls, data):
         if isinstance(data, str):
-            return str
+            return cls.__dtypes.get("str")
+        elif isinstance(data, bytes):
+            return cls.__dtypes.get("bytes")
         elif not hasattr(data, '__len__'):
             return type(data)
         else:
@@ -1230,8 +1233,8 @@ class ZarrIO(HDMFIO):
             # which Zarr does not allow for dataset shape. Check for the shape attribute first before falling
             # back on get_data_shape
             if hasattr(data, 'shape') and data.shape is not None:
-                data_shape = data.shape  
-            # This is a fall-back just in case. However this should not happen for standard numpy and h5py arrays 
+                data_shape = data.shape
+            # This is a fall-back just in case. However this should not happen for standard numpy and h5py arrays
             else: # pragma: no cover
                 data_shape = get_data_shape(data) # pragma: no cover
         # Deal with object dtype

--- a/tests/unit/test_io_convert.py
+++ b/tests/unit/test_io_convert.py
@@ -36,6 +36,8 @@ import os
 import shutil
 import numpy as np
 import numcodecs
+from datetime import datetime
+from dateutil import tz
 from abc import ABCMeta, abstractmethod
 
 from hdmf_zarr.backend import (ZarrIO,
@@ -49,7 +51,6 @@ from hdmf.testing import TestCase
 from hdmf.common import DynamicTable
 from hdmf.common import CSRMatrix
 
-
 from tests.unit.utils import (Foo, FooBucket, FooFile, get_foo_buildmanager,
                               Baz, BazData, BazBucket, get_baz_buildmanager,
                               BazCpdData, get_temp_filepath)
@@ -57,6 +58,12 @@ from tests.unit.utils import (Foo, FooBucket, FooFile, get_foo_buildmanager,
 from zarr.storage import (DirectoryStore,
                           TempStore,
                           NestedDirectoryStore)
+try:
+    import pynwb
+    PYNWB_AVAILABLE = True
+except ImportError:
+    PYNWB_AVAILABLE = False
+
 
 
 class MixinTestCaseConvert(metaclass=ABCMeta):
@@ -403,6 +410,45 @@ class MixinTestFoo():
         else:
             raise NotImplementedError("FOO_TYPE %i not implemented in test" % self.FOO_TYPE)
 
+############################################
+# HDMF Common test container mixins
+###########################################
+class MixinTestNWBFile():
+    """
+    Mixin class used in conjunction with MixinTestCaseConvert to create conversion tests that
+    test export of a basic NWBFile. This class only defines the setUpContainer function for the test.
+    The roundtripExportContainer function required for the test needs to be defined separately
+    (e.g., by another mixin or the test class itself)
+    This mixin adds the class variable, ``TABLE_TYPE``  which is an int to select between different
+    container types for testing:
+
+    * ``TABLE_TYPE=0`` : Table of int, float, bool, Enum
+    * ``TABLE_TYPE=1`` : Table of int, float, str, bool, Enum
+    """
+    TABLE_TYPE = 0
+
+    def get_manager(self):
+        return pynwb.get_manager()
+
+    def setUpContainer(self):
+        if not PYNWB_AVAILABLE:
+            self.skipTest('Skip test. PyNWB is not installed')
+
+        subject = pynwb.file.Subject(
+            subject_id="001",
+            species="Mus musculus",
+            sex="M",
+            date_of_birth=datetime(2018, 4, 25, 2, 30, 3, tzinfo=tz.gettz("US/Pacific")),
+            age="P1D",
+            description=None,
+        )
+        nwbfile = pynwb.file.NWBFile(
+            session_description="Test File",
+            identifier="0000",
+            session_start_time=datetime(2019, 4, 25, 2, 30, 3, tzinfo=tz.gettz("US/Pacific")),
+            subject=subject,
+        )
+        return nwbfile
 
 ########################################
 # HDMF Baz test dataset of references
@@ -637,6 +683,44 @@ class TestHDF5toZarrFooCase2(MixinTestFoo,
     IGNORE_HDMF_ATTRS = True
     IGNORE_STRING_TO_BYTE = True
     FOO_TYPE = MixinTestFoo.FOO_TYPES['link_data']
+
+
+class TestZarrToZarrNWBFile(MixinTestNWBFile,
+                            MixinTestZarrToZarr,
+                            MixinTestCaseConvert,
+                            TestCase):
+    """
+    Test the conversion of DynamicTable containers from Zarr to HDF5.
+    See MixinTestDynamicTableContainer.setUpContainer for the container spec.
+    """
+    IGNORE_NAME = True
+    IGNORE_HDMF_ATTRS = True
+    IGNORE_STRING_TO_BYTE = False
+
+
+class TestHDF5ToZarrNWBFile(MixinTestNWBFile,
+                            MixinTestHDF5ToZarr,
+                            MixinTestCaseConvert,
+                            TestCase):
+    """
+    Test the conversion of DynamicTable containers from Zarr to HDF5.
+    See MixinTestDynamicTableContainer.setUpContainer for the container spec.
+    """
+    IGNORE_NAME = True
+    IGNORE_HDMF_ATTRS = True
+    IGNORE_STRING_TO_BYTE = False
+
+class TestZarrToHDF5NWBFile(MixinTestNWBFile,
+                            MixinTestZarrToHDF5,
+                            MixinTestCaseConvert,
+                            TestCase):
+    """
+    Test the conversion of DynamicTable containers from Zarr to HDF5.
+    See MixinTestDynamicTableContainer.setUpContainer for the container spec.
+    """
+    IGNORE_NAME = True
+    IGNORE_HDMF_ATTRS = True
+    IGNORE_STRING_TO_BYTE = False
 
 
 ########################################

--- a/tests/unit/test_io_convert.py
+++ b/tests/unit/test_io_convert.py
@@ -419,11 +419,6 @@ class MixinTestNWBFile():
     test export of a basic NWBFile. This class only defines the setUpContainer function for the test.
     The roundtripExportContainer function required for the test needs to be defined separately
     (e.g., by another mixin or the test class itself)
-    This mixin adds the class variable, ``TABLE_TYPE``  which is an int to select between different
-    container types for testing:
-
-    * ``TABLE_TYPE=0`` : Table of int, float, bool, Enum
-    * ``TABLE_TYPE=1`` : Table of int, float, str, bool, Enum
     """
     TABLE_TYPE = 0
 


### PR DESCRIPTION
## Motivation

* Fix #160
* Updated `ZarrIO.get_type` to resolve `bytes` dtype
* Add test mixin to test rountrip conversion for a minimal NWB file

* Updated 

## How to test the behavior?

```
pytest
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
