### PR TITLE
Update deprecated actions in deploy and release yaml

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install build dependencies
         run: |
@@ -45,7 +45,7 @@ jobs:
           ls -1 dist
           # twine upload --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.BOT_PYPI_USER }} -p ${{ secrets.BOT_PYPI_PASSWORD }} --skip-existing dist/*
           twine upload -u ${{ secrets.BOT_PYPI_USER }} -p ${{ secrets.BOT_PYPI_PASSWORD }} --skip-existing dist/*
-          
+
       - name: Publish wheel and source distributions as a GitHub release
         run: |
           python -m pip install "githubrelease>=1.5.9"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Fixed bug in `pyproject.toml` where duplicate versions of `numcodec` where specified. @oruebel [#163](https://github.com/hdmf-dev/hdmf-zarr/pull/163)
 
 ### Internal Fixes
-* Updated actions in `deploy_release.yml` workflow to avoid use of deprecated Node.js 16 . @oruebel [#165](https://github.com/hdmf-dev/hdmf-zarr/pull/165)
+* Updated actions in `deploy_release.yml` workflow to avoid use of deprecated Node.js 16. @oruebel [#165](https://github.com/hdmf-dev/hdmf-zarr/pull/165)
 
 
 ## 0.5.0 (December 8, 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * Adjusted gallery tests to not fail on deprecation warnings from pandas. @rly [#157](https://github.com/hdmf-dev/hdmf-zarr/pull/157)
 * Fixed bug in `pyproject.toml` where duplicate versions of `numcodec` where specified. @oruebel [#163](https://github.com/hdmf-dev/hdmf-zarr/pull/163)
 
+### Internal Fixes
+* Updated actions in `deploy_release.yml` workflow to avoid use of deprecated Node.js 16 . @oruebel [#165](https://github.com/hdmf-dev/hdmf-zarr/pull/165)
+
+
 ## 0.5.0 (December 8, 2023)
 
 ### Enhancements


### PR DESCRIPTION
## Motivation

The Deploy and release workflow is out-of-date with node version requirements


## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
