### PR TITLE
Add sdupport for r- read mode to read without consolidated metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Docs
 * Removed `linkable` from the documentation to keep in line with `hdmf-schema-language`. @mavaylon1 [#180](https://github.com/hdmf-dev/hdmf-zarr/pull/180)
 
+### Internal Fixes
+* Fixed minor bug where `ZarrIO.__open_file_consolidated` used properties of `ZarrIO` instead of the provided input parameters. @oruebel [#183](https://github.com/hdmf-dev/hdmf-zarr/pull/183) 
+
 ## 0.6.0 (February 21, 2024)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.0 (Upcoming)
 ### Enhancements
 * Added support for python 3.12. @mavaylon1 [#172](https://github.com/hdmf-dev/hdmf-zarr/pull/172)
+* Added support for forcing read of files without consolidated metadata using  `mode=r-` in `ZarrIO`. @oruebel [#183](https://github.com/hdmf-dev/hdmf-zarr/pull/183)
 
 ### Docs
 * Removed `linkable` from the documentation to keep in line with `hdmf-schema-language`. @mavaylon1 [#180](https://github.com/hdmf-dev/hdmf-zarr/pull/180)

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -88,7 +88,8 @@ class ZarrIO(HDMFIO):
              'doc': 'the path to the Zarr file or a supported Zarr store'},
             {'name': 'manager', 'type': BuildManager, 'doc': 'the BuildManager to use for I/O', 'default': None},
             {'name': 'mode', 'type': str,
-             'doc': 'the mode to open the Zarr file with, one of ("w", "r", "r+", "a", "w-")'},
+             'doc': 'the mode to open the Zarr file with, one of ("w", "r", "r+", "a", "w-") '
+                    'the mode r- is used to force open without consolidated metadata in read only mode.'},
             {'name': 'synchronizer', 'type': (zarr.ProcessSynchronizer, zarr.ThreadSynchronizer, bool),
              'doc': 'Zarr synchronizer to use for parallel I/O. If set to True a ProcessSynchronizer is used.',
              'default': None},
@@ -161,7 +162,7 @@ class ZarrIO(HDMFIO):
             # As a result, when in other modes, the file will not use consolidated metadata.
             if self.__mode not in ['r', 'r+']:
                 self.__file = zarr.open(store=self.path,
-                                        mode=self.__mode,
+                                        mode=self.__mode if self.__mode is not 'r-' else 'r',
                                         synchronizer=self.__synchronizer,
                                         storage_options=self.__storage_options)
             else:

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -161,8 +161,11 @@ class ZarrIO(HDMFIO):
             # Within zarr, open_consolidated only allows the mode to be 'r' or 'r+'.
             # As a result, when in other modes, the file will not use consolidated metadata.
             if self.__mode not in ['r', 'r+']:
+                # r- is only an internal mode in ZarrIO to force the use of regular open. For Zarr we need to
+                # use the regular mode r when r- is specified
+                mode_to_use = self.__mode if self.__mode != 'r-' else 'r'
                 self.__file = zarr.open(store=self.path,
-                                        mode=self.__mode if self.__mode != 'r-' else 'r',
+                                        mode=mode_to_use,
                                         synchronizer=self.__synchronizer,
                                         storage_options=self.__storage_options)
             else:

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -162,7 +162,7 @@ class ZarrIO(HDMFIO):
             # As a result, when in other modes, the file will not use consolidated metadata.
             if self.__mode not in ['r', 'r+']:
                 self.__file = zarr.open(store=self.path,
-                                        mode=self.__mode if self.__mode is not 'r-' else 'r',
+                                        mode=self.__mode if self.__mode != 'r-' else 'r',
                                         synchronizer=self.__synchronizer,
                                         storage_options=self.__storage_options)
             else:
@@ -479,6 +479,9 @@ class ZarrIO(HDMFIO):
         This method will check to see if the metadata has been consolidated.
         If so, use open_consolidated.
         """
+        # This check is just a safeguard for possible errors in the future. But this should never happen
+        if mode == 'r-':
+            raise ValueError('Mode r- not allowed for reading with consolidated metadata')
         # self.path can be both a string or a one of the `SUPPORTED_ZARR_STORES`.
         if isinstance(self.path, str):
             path = self.path
@@ -491,10 +494,10 @@ class ZarrIO(HDMFIO):
                                           synchronizer=synchronizer,
                                           storage_options=storage_options)
         else:
-            return zarr.open(store=self.path,
-                             mode=self.__mode,
-                             synchronizer=self.__synchronizer,
-                             storage_options=self.__storage_options)
+            return zarr.open(store=store,
+                             mode=mode,
+                             synchronizer=synchronizer,
+                             storage_options=storage_options)
 
     @docval({'name': 'parent', 'type': Group, 'doc': 'the parent Zarr object'},
             {'name': 'builder', 'type': GroupBuilder, 'doc': 'the GroupBuilder to write'},
@@ -724,7 +727,9 @@ class ZarrIO(HDMFIO):
         else:
             target_name = ROOT_NAME
 
-        target_zarr_obj = self.__open_file_consolidated(source_file, mode='r', storage_options=self.__storage_options)
+        target_zarr_obj = self.__open_file_consolidated(store=source_file,
+                                                        mode='r',
+                                                        storage_options=self.__storage_options)
         if object_path is not None:
             try:
                 target_zarr_obj = target_zarr_obj[object_path]

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -96,7 +96,8 @@ class ZarrStoreTestCase(TestCase):
         self.store = "tests/unit/test_io.zarr"
 
     def tearDown(self):
-        shutil.rmtree(self.store)
+        if os.path.exists(self.store):
+            shutil.rmtree(self.store)
 
     def createReferenceBuilder(self):
         data_1 = np.arange(100, 200, 10).reshape(2, 5)


### PR DESCRIPTION
## Motivation

For benchmarking and when consolidated metadata may be bad, it will be useful to force reading without consolidated metadata. This is needed for the nwb-benchmarks. 

This PR:
-  adds a new mode `r-` to force that a file is opened in `r` mode without using consolidated metadata. 
- fixes a  bug where `ZarrIO.__open_file_consolidated` used properties of `ZarrIO` instead of the provided input parameters. This did not cause any errors so far, since the values matched but is still something that could have caused issues later on.
- adds unit tests for `-r` read mode
- fixes a minor bug in`ZarrStoreTestCase` which assumed in the `tearDown` that the output file was always being created, so clean-up would fail if a test-case did not create a file. 


## Checklist

- [X] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
