### PR TITLE
Fix bug in ZarrIO.__open_consolidated 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 ### Docs
 * Removed `linkable` from the documentation to keep in line with `hdmf-schema-language`. @mavaylon1 [#180](https://github.com/hdmf-dev/hdmf-zarr/pull/180)
 
-### Internal Fixes
+### Bug Fixes
+* Fixed bug in `ZarrIO.__open_file_consolidated` that led to remote files being opened without consolidated metadata. @oruebel  [#184](https://github.com/hdmf-dev/hdmf-zarr/pull/184) 
 * Fixed minor bug where `ZarrIO.__open_file_consolidated` used properties of `ZarrIO` instead of the provided input parameters. @oruebel [#183](https://github.com/hdmf-dev/hdmf-zarr/pull/183) 
 
 ## 0.6.0 (February 21, 2024)

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -491,12 +491,12 @@ class ZarrIO(HDMFIO):
         else:
             path = self.path.path
 
-        if os.path.isfile(path+'/.zmetadata'):
+        try:
             return zarr.open_consolidated(store=store,
                                           mode=mode,
                                           synchronizer=synchronizer,
                                           storage_options=storage_options)
-        else:
+        except KeyError:  # A KeyError is raised when the '/.zmetadata' does not exist
             return zarr.open(store=store,
                              mode=mode,
                              synchronizer=synchronizer,

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -485,12 +485,6 @@ class ZarrIO(HDMFIO):
         # This check is just a safeguard for possible errors in the future. But this should never happen
         if mode == 'r-':
             raise ValueError('Mode r- not allowed for reading with consolidated metadata')
-        # self.path can be both a string or a one of the `SUPPORTED_ZARR_STORES`.
-        if isinstance(self.path, str):
-            path = self.path
-        else:
-            path = self.path.path
-
         try:
             return zarr.open_consolidated(store=store,
                                           mode=mode,


### PR DESCRIPTION
## Motivation

`ZarrIO.__open_consolidated`` currently used the following check `if os.path.isfile(path+'/.zmetadata'):` to determine whether the file should be open with consolidated metadata or without. This check, however, assumes that the file is local and will not work for remote files stored on S3. 

## Changes

To address this issue this PR changes to a try/except logic instead. `zarr.open_consolidated` will raise a  `KeyError` if the `.zmetata` is missing so we can just try to open the file this way first and the fall back to the regular method if it fails. 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
