### PR TITLE
Don't open with consolidated metadata in mode r+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 ## 0.8.0 (Upcoming)
 ### Bug Fixes
 * Fixed bug when opening a file in with `mode=r+`. The file will open without using the consolidated metadata. @mavaylon1 [#182](https://github.com/hdmf-dev/hdmf-zarr/issues/182)
-
-## 0.7.0 (May 2, 2024)
-### Bug Fixes
 * Fixed bug on how we access scalar arrays. Added warning filter for Zarr deprecation of NestedDirectoryStore. Fixed bug on how we write a dataset of references. @mavaylon1 [#195](https://github.com/hdmf-dev/hdmf-zarr/pull/195)
 
 ## 0.7.0 (May 2, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HDMF-ZARR Changelog
 
+## 0.8.0 (Upcoming)
+### Bug Fixes
+* Fixed bug when opening a file in with `mode=r+`. The file will open without using the consolidated metadata. @mavaylon1 [#182](https://github.com/hdmf-dev/hdmf-zarr/issues/182)
+
 ## 0.7.0 (May 2, 2024)
 ### Enhancements
 * Added support for python 3.12. @mavaylon1 [#172](https://github.com/hdmf-dev/hdmf-zarr/pull/172)

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1454,7 +1454,7 @@ class ZarrIO(HDMFIO):
 
         # Read scalar dataset
         if dtype == 'scalar':
-            data = zarr_obj[0]
+            data = zarr_obj[()]
 
         if isinstance(dtype, list):
             # Check compound dataset where one of the subsets contains references

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -160,7 +160,9 @@ class ZarrIO(HDMFIO):
         if self.__file is None:
             # Within zarr, open_consolidated only allows the mode to be 'r' or 'r+'.
             # As a result, when in other modes, the file will not use consolidated metadata.
-            if self.__mode not in ['r', 'r+']:
+            if self.__mode != 'r':
+                # When we consolidate metadata, we use ConsolidatedMetadataStore. This interface does not seem to allow for setting items at all.
+                # In the doc string, it says it is "read only". As a result, we cannot use r+ with consolidate_metadata.
                 # r- is only an internal mode in ZarrIO to force the use of regular open. For Zarr we need to
                 # use the regular mode r when r- is specified
                 mode_to_use = self.__mode if self.__mode != 'r-' else 'r'

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -161,7 +161,8 @@ class ZarrIO(HDMFIO):
             # Within zarr, open_consolidated only allows the mode to be 'r' or 'r+'.
             # As a result, when in other modes, the file will not use consolidated metadata.
             if self.__mode != 'r':
-                # When we consolidate metadata, we use ConsolidatedMetadataStore. This interface does not seem to allow for setting items at all.
+                # When we consolidate metadata, we use ConsolidatedMetadataStore.
+                # This interface does not seem to allow for setting items at all.
                 # In the doc string, it says it is "read only". As a result, we cannot use r+ with consolidate_metadata.
                 # r- is only an internal mode in ZarrIO to force the use of regular open. For Zarr we need to
                 # use the regular mode r when r- is specified

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -162,7 +162,7 @@ class ZarrIO(HDMFIO):
             # As a result, when in other modes, the file will not use consolidated metadata.
             if self.__mode != 'r':
                 # When we consolidate metadata, we use ConsolidatedMetadataStore.
-                # This interface does not seem to allow for setting items at all.
+                # This interface does not allow for setting items.
                 # In the doc string, it says it is "read only". As a result, we cannot use r+ with consolidate_metadata.
                 # r- is only an internal mode in ZarrIO to force the use of regular open. For Zarr we need to
                 # use the regular mode r when r- is specified


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.
Fix #182 

The fix is to open without consolidated metadata when in mode r+.

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
