### PR TITLE
Update for zarr 2.18.0 and zarr 2.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.0 (May 2, 2024)
 ### Bug Fixes
-* Fixed bug on how we access scalar arrays. Added warning filter for Zarr deprecation of NestedDirectoryStore. @mavaylon1 [#195](https://github.com/hdmf-dev/hdmf-zarr/pull/195)
+* Fixed bug on how we access scalar arrays. Added warning filter for Zarr deprecation of NestedDirectoryStore. Fixed bug on how we write a dataset of references. @mavaylon1 [#195](https://github.com/hdmf-dev/hdmf-zarr/pull/195)
 
 ## 0.7.0 (May 2, 2024)
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # HDMF-ZARR Changelog
 
 ## 0.7.0 (May 2, 2024)
+### Bug Fixes
+* Fixed bug on how we access scalar arrays. @mavaylon1 [#195](https://github.com/hdmf-dev/hdmf-zarr/pull/195)
+
+## 0.7.0 (May 2, 2024)
 ### Enhancements
 * Added support for python 3.12. @mavaylon1 [#172](https://github.com/hdmf-dev/hdmf-zarr/pull/172)
 * Added support for forcing read of files without consolidated metadata using  `mode=r-` in `ZarrIO`. @oruebel [#183](https://github.com/hdmf-dev/hdmf-zarr/pull/183)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.0 (May 2, 2024)
 ### Bug Fixes
-* Fixed bug on how we access scalar arrays. @mavaylon1 [#195](https://github.com/hdmf-dev/hdmf-zarr/pull/195)
+* Fixed bug on how we access scalar arrays. Added warning filter for Zarr deprecation of NestedDirectoryStore. @mavaylon1 [#195](https://github.com/hdmf-dev/hdmf-zarr/pull/195)
 
 ## 0.7.0 (May 2, 2024)
 ### Enhancements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     'hdmf>=3.9.0',
-    'zarr>=2.11.0, <2.18',
+    'zarr>=2.11.0',
     'numpy>=1.24, <2.0', # pin below 2.0 until HDMF supports numpy 2.0
     'numcodecs>=0.9.1',
     'pynwb>=2.5.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     'hdmf>=3.9.0',
-    'zarr>=2.11.0',
+    'zarr>=2.11.0, <2.18',
     'numpy>=1.24, <2.0', # pin below 2.0 until HDMF supports numpy 2.0
     'numcodecs>=0.9.1',
     'pynwb>=2.5.0',

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1096,7 +1096,7 @@ class ZarrIO(HDMFIO):
             self._written_builders.set_written(builder)  # record that the builder has been written
             dset.attrs['zarr_dtype'] = type_str
             if hasattr(refs, '__len__'):
-                dset[:] = refs
+                dset[:] = np.array(refs)
             else:
                 dset[0] = refs
         # write a 'regular' dataset without DatasetIO info
@@ -1453,7 +1453,6 @@ class ZarrIO(HDMFIO):
         # Read scalar dataset
         if dtype == 'scalar':
             data = zarr_obj[()]
-
         if isinstance(dtype, list):
             # Check compound dataset where one of the subsets contains references
             has_reference = False

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1451,7 +1451,7 @@ class ZarrIO(HDMFIO):
 
         # Read scalar dataset
         if dtype == 'scalar':
-            data = zarr_obj[0]
+            data = zarr_obj[()]
 
         if isinstance(dtype, list):
             # Check compound dataset where one of the subsets contains references

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1287,7 +1287,8 @@ class ZarrIO(HDMFIO):
         # standard write
         else:
             try:
-                dset[:] = data  # If data is an h5py.Dataset then this will copy the data
+                # breakpoint()
+                dset[:] = np.array(data)  # If data is an h5py.Dataset then this will copy the data
             # For compound data types containing strings Zarr sometimes does not like writing multiple values
             # try to write them one-at-a-time instead then
             except ValueError:

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1287,8 +1287,8 @@ class ZarrIO(HDMFIO):
         # standard write
         else:
             try:
-                # breakpoint()
-                dset[:] = np.array(data)  # If data is an h5py.Dataset then this will copy the data
+                dset[:] = np.array(data)
+            # If data is an h5py.Dataset then this will copy the data
             # For compound data types containing strings Zarr sometimes does not like writing multiple values
             # try to write them one-at-a-time instead then
             except ValueError:

--- a/test_gallery.py
+++ b/test_gallery.py
@@ -77,6 +77,9 @@ _deprecation_warning_datetime = (
     r"datetime.datetime.utcfromtimestamp() *"
 )
 
+_deprecation_warning_zarr_store = (
+    r"The NestedDirectoryStore is deprecated *"
+
 def run_gallery_tests():
     global TOTAL, FAILURES, ERRORS
     logging.info("Testing execution of Sphinx Gallery files")
@@ -141,6 +144,9 @@ def run_gallery_tests():
                 warnings.filterwarnings(
                     # this is triggered from datetime
                     "ignore", message=_deprecation_warning_datetime, category=DeprecationWarning
+                )
+                warnings.filterwarnings(
+                    "ignore", message=_deprecation_warning_zarr_store, category=FutureWarning
                 )
                 _import_from_file(script_abs)
         except Exception:

--- a/test_gallery.py
+++ b/test_gallery.py
@@ -79,6 +79,7 @@ _deprecation_warning_datetime = (
 
 _deprecation_warning_zarr_store = (
     r"The NestedDirectoryStore is deprecated *"
+)
 
 def run_gallery_tests():
     global TOTAL, FAILURES, ERRORS


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.
This PR is to update hdmf-zarr for changes that came n 2.18.0 and new changes in 2.18.0

2.18.0
This is in response to the failing workflows using the latest version of zarr, specifically the failing test test_fsspec_streaming.

The issue is how we are reading zarr scalar arrays. We are currently trying to directly index and access the scalar. From looking at the documentation, zarr accessed a scalar array as `z[:]`, which seems to solve the problem. I also saw that `z[()]` was another syntax that works. 

Why?
Not completely clear.
When we access a scalar array in numpy we do so with notation `[()]`. Supposedly, Zarr used to support indexing scalar arrays as `z[0]`, but that was updated to numpy standard earlier in one of the zarr version 2.#. Maybe this was a functionality that finally got flushed out fully. 

**2.18.1**
To ensure that the data being assigned is in a format that the Zarr array can handle efficiently, Zarr arrays seem to require that we set with numpy arrays, i.e., `dset[:] = np.array(data)`.

Another weird behavior is when setting a dataset of references, the current method puts the entire dataset in each index vs matching the individual reference dictionary to the index (which is what we expect). 

The solution to both is make sure the data is in an array first. 

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
