### PR TITLE
Update upload-artifact action to match download-artifact

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -61,7 +61,7 @@ jobs:
           tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
       - name: Upload distribution as a workspace artifact
         if: ${{ matrix.upload-wheels }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: distributions
           path: dist


### PR DESCRIPTION
They need to be the same major version.

Changelog update not needed.