### PR TITLE
Fix broken Python 3.9 tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # pinned dependencies to reproduce an entire development environment to use HDMF-ZARR
 hdmf==3.14.5
-zarr==2.18.3
+zarr==2.18.3; python_version >= "3.10"  # zarr 2.18.3 dropped support for python 3.9
+zarr==2.18.2; python_version < "3.10"
 pynwb==2.8.2
 numpy==2.1.3
 numcodecs==0.13.1


### PR DESCRIPTION
## Motivation

zarr 2.18.3 dropped support for Python 3.9 so our daily run all tests workflow is failing for Python 3.9 runs. I think a changelog entry is not needed for this change.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
