### PR TITLE
Fix export cache spec and fix read cached spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # HDMF-ZARR Changelog
 
 ## 1.0.0 (Upcoming)
+
 ### Enhancements
 * Added support for Pathlib paths. @mavaylon1 [#212](https://github.com/hdmf-dev/hdmf-zarr/pull/212)
 * Updated packages used for testing and readthedocs configuration. @mavaylon1, @rly [#214](https://github.com/hdmf-dev/hdmf-zarr/pull/214)
 * Add `force_overwite` parameter for `ZarrIO.__init__` to allow overwriting an existing file or directory. @oruebel [#229](https://github.com/hdmf-dev/hdmf-zarr/pull/229)
+
+### Bug Fixes
+* Fix reading of cached specs and caching of specs during export. @rly [#232](https://github.com/hdmf-dev/hdmf-zarr/pull/232)
 
 ## 0.9.0 (September 16, 2024)
 ### Enhancements

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -399,6 +399,13 @@ class ZarrIO(HDMFIO):
             ckwargs['clear_cache'] = True
         super().export(**ckwargs)
         if cache_spec:
+            # add any namespaces from the src_io that have not yet been loaded
+            for namespace in src_io.manager.namespace_catalog.namespaces:
+                if namespace not in self.manager.namespace_catalog.namespaces:
+                    self.manager.namespace_catalog.add_namespace(
+                        name=namespace,
+                        namespace=src_io.manager.namespace_catalog.get_namespace(namespace)
+                    )
             self.__cache_spec()
 
     def get_written(self, builder, check_on_disk=False):


### PR DESCRIPTION
## Motivation

Fix #145. Cached extensions that are not one of {core, hdmf-common, hdmf-experimental} were not being exported into the Zarr store. In addition, cached extensions were not being read correctly because the name of the ZarrSpecReader source was being set to "./namespace" rather than something unique to the spec. The specs were also not being cached. This PR makes the code for `ZarrSpecReader` more aligned with `H5SpecReader`.

## How to test the behavior?
Run example code in #145 but you need to use this branch in HDMF to read the file https://github.com/hdmf-dev/hdmf/pull/1205

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
