### PR TITLE
Fix broken conda 3.9 test

### DIFF
--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -132,7 +132,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.9-minimum    , test-tox-env: py39-minimum    , build-tox-env: build-py39-minimum    , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: conda-linux-python3.9-minimum    , test-tox-env: py39-minimum    , build-tox-env: build-py39-minimum    , python-ver: "3.9" , os: ubuntu-latest }
           - { name: conda-linux-python3.10           , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: ubuntu-latest }
           - { name: conda-linux-python3.11           , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: ubuntu-latest }
           - { name: conda-linux-python3.12           , test-tox-env: py312           , build-tox-env: build-py312           , python-ver: "3.12", os: ubuntu-latest }  


### PR DESCRIPTION
There is a typo in the conda-linux-python3.9-minimum workflow causing the nightly tests to fail.