### PR TITLE
Fix coverage workflow and update GH templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,24 +49,15 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: executable
-    attributes:
-      label: Python Executable
-      options:
-        - Conda
-        - Python
-    validations:
-      required: true
-  - type: dropdown
     id: python_version
     attributes:
       label: Python Version
       options:
-        - "3.9"
-        - "3.10"
-        - "3.11"
-        - "3.12"
         - "3.13"
+        - "3.12"
+        - "3.11"
+        - "3.10"
+        - "3.9"
     validations:
       required: true
   - type: textarea
@@ -80,15 +71,11 @@ body:
 
         You can attach images or log files by clicking this area to highlight it and then dragging files in.
         If GitHub upload is not working, you can also copy and paste the output into this section.
-  - type: checkboxes
-    id: terms
+  - type: markdown
     attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/.github/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow this project's [Code of Conduct](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/.github/CODE_OF_CONDUCT.md)
-          required: true
-        - label: Have you checked the [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
-          required: true
-        - label: Have you ensured this bug was not already [reported](https://github.com/hdmf-dev/hdmf-zarr/issues)?
-          required: true
+      value: |
+        By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/.github/CODE_OF_CONDUCT.md).
+
+        Before submitting this issue, please review the [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst).
+
+        Please also ensure that this issue has not already been [reported](https://github.com/hdmf-dev/hdmf-zarr/issues). Thank you!

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,7 @@
 name: Documentation
 description: Is the documentation of something missing, unclear, or lacking? This is the place.
 title: "[Documentation]: "
-labels: "documentation"
+labels: ["documentation"]
 body:
   - type: markdown
     attributes:
@@ -32,15 +32,11 @@ body:
         - No.
     validations:
       required: true
-  - type: checkboxes
-    id: terms
+  - type: markdown
     attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/.github/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow this project's [Code of Conduct](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/.github/CODE_OF_CONDUCT.md)
-          required: true
-        - label: Have you checked the [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
-          required: true
-        - label: Have you ensured this change was not already [requested](https://github.com/hdmf-dev/hdmf-zarr/issues)?
-          required: true
+      value: |
+        By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/.github/CODE_OF_CONDUCT.md).
+
+        Before submitting this issue, please review the [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst).
+
+        Please also ensure that this issue has not already been [reported](https://github.com/hdmf-dev/hdmf-zarr/issues). Thank you!

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -50,15 +50,11 @@ body:
         - No.
     validations:
       required: true
-  - type: checkboxes
-    id: terms
+  - type: markdown
     attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/.github/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow this project's [Code of Conduct](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/.github/CODE_OF_CONDUCT.md)
-          required: true
-        - label: Have you checked the [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
-          required: true
-        - label: Have you ensured this change was not already [requested](https://github.com/hdmf-dev/hdmf-zarr/issues)?
-          required: true
+      value: |
+        By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/.github/CODE_OF_CONDUCT.md).
+
+        Before submitting this issue, please review the [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst).
+
+        Please also ensure that this issue has not already been [reported](https://github.com/hdmf-dev/hdmf-zarr/issues). Thank you!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,9 +9,7 @@ Show how to reproduce the new behavior (can be a bug fix or a new feature)
 
 ## Checklist
 
-- [ ] Did you update CHANGELOG.md with your changes?
-- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst) document?
-- [ ] Have you ensured the PR clearly describes the problem and the solution?
-- [ ] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
-- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf-zarr/pulls) for the same change?
-- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
+- [ ] Did you update `CHANGELOG.md` with your changes?
+- [ ] Does the PR clearly describe the problem and the solution?
+- [ ] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
+- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?

--- a/.github/workflows/HDMF_dev.yaml
+++ b/.github/workflows/HDMF_dev.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags are required to determine the version
       
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -103,6 +105,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -142,6 +146,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -46,7 +46,7 @@ jobs:
           python -m pip install --upgrade pip
 
       - name: Install package
-        if: ! ${{ matrix.opt_req }}
+        if: ${{ ! matrix.opt_req }}
         run: |
           python -m pip install ".[test]"
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -91,6 +93,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -126,6 +130,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v3
@@ -175,6 +181,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
1. Fixed a typo in the coverage workflow that prevented it from being run.
2. Fixed bug in the workflows preventing the package version from being detected.
3. Simplified GH templates a bit and aligned them with those used by HDMF.