### PR TITLE
Use RTD stable release, remove auto GH pre-release

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Read the Documentation
-    url: https://hdmf-zarr.readthedocs.io/en/latest/
+    url: https://hdmf-zarr.readthedocs.io
     about: Check out the full documentation.

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - dev
-    tags-ignore:  # exclude tags created by "ci_addons publish_github_release"
-      - 'latest'
-      - 'latest-tmp'
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - dev
-    tags-ignore:  # exclude tags created by "ci_addons publish_github_release"
-      - 'latest'
-      - 'latest-tmp'
   pull_request:
 
 jobs:
@@ -22,16 +19,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.9-minimum  , test-tox-env: py39-minimum  , python-ver: "3.9" , os: ubuntu-latest }
-          # NOTE config below with "upload-wheels: true" specifies that wheels should be uploaded as an artifact
-          - { name: linux-python3.13         , test-tox-env: py313         , python-ver: "3.13", os: ubuntu-latest , upload-wheels: true }
-          - { name: linux-python3.13-optional, test-tox-env: py313-optional, python-ver: "3.13", os: ubuntu-latest }
-          - { name: windows-python3.9-minimum, test-tox-env: py39-minimum  , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-python3.13       , test-tox-env: py313         , python-ver: "3.13", os: windows-latest }
+          - { name: linux-python3.9-minimum    , test-tox-env: py39-minimum  , python-ver: "3.9" , os: ubuntu-latest }
+          - { name: linux-python3.13           , test-tox-env: py313         , python-ver: "3.13", os: ubuntu-latest }
+          - { name: linux-python3.13-optional  , test-tox-env: py313-optional, python-ver: "3.13", os: ubuntu-latest }
+          - { name: windows-python3.9-minimum  , test-tox-env: py39-minimum  , python-ver: "3.9" , os: windows-latest }
+          - { name: windows-python3.13         , test-tox-env: py313         , python-ver: "3.13", os: windows-latest }
           - { name: windows-python3.13-optional, test-tox-env: py313-optional, python-ver: "3.13", os: windows-latest }
-          - { name: macos-python3.9-minimum  , test-tox-env: py39-minimum  , python-ver: "3.9" , os: macos-latest }
-          - { name: macos-python3.13         , test-tox-env: py313         , python-ver: "3.13", os: macos-latest }
-          - { name: macos-python3.13-optional, test-tox-env: py313-optional, python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.9-minimum    , test-tox-env: py39-minimum  , python-ver: "3.9" , os: macos-latest }
+          - { name: macos-python3.13           , test-tox-env: py313         , python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.13-optional  , test-tox-env: py313-optional, python-ver: "3.13", os: macos-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -65,13 +61,6 @@ jobs:
       - name: Test installation from a source distribution
         run: |
           tox -e wheelinstall --recreate --installpkg dist/*.tar.gz
-
-      - name: Upload distribution as a workspace artifact
-        if: ${{ matrix.upload-wheels }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: distributions
-          path: dist
 
   run-gallery-tests:
     name: ${{ matrix.name }}
@@ -170,40 +159,3 @@ jobs:
       - name: Test installation from a source distribution
         run: |
           tox -e wheelinstall --recreate --installpkg dist/*.tar.gz
-
-  deploy-dev:
-    name: Deploy pre-release from dev
-    needs: [run-tests, run-gallery-tests, run-tests-on-conda]
-    if: ${{ github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # tags are required to determine the version
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Download wheel and source distributions from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: distributions
-          path: dist
-
-      - name: Publish wheel and source distributions as a GitHub release
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install scikit-ci-addons
-          ci_addons publish_github_release hdmf-dev/hdmf-zarr  \
-              --prerelease-packages "dist/*" \
-              --prerelease-sha $GITHUB_SHA \
-              --prerelease-packages-clear-pattern "*" \
-              --prerelease-packages-keep-pattern "*dev<COMMIT_DISTANCE>*" \
-              --token ${{ secrets.BOT_GITHUB_TOKEN }} \
-              --re-upload

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,10 +14,6 @@ build:
 sphinx:
   configuration: docs/source/conf.py
 
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
-
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
@@ -25,8 +21,3 @@ formats: all
 python:
   install:
     - path: .[docs,full] # path to the package relative to the root
-
-# Optionally include all submodules
-submodules:
-  include: all
-  recursive: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # HDMF-ZARR Changelog
 
+## [Unreleased]
+
+### Changed
+* Adopted changelog format conventions: https://keepachangelog.com/en/1.0.0/ . @rly [#254](https://github.com/hdmf-dev/hdmf-zarr/pull/254)
+* Made docs site point to latest stable release: https://hdmf-zarr.readthedocs.io/en/stable/ instead of "latest" tag. @rly [#254](https://github.com/hdmf-dev/hdmf-zarr/pull/254)
+* Removed GitHub Actions workflow that automatically generated GitHub pre-releases on the "latest" tag on each commit to dev to simplify maintenance. @rly [#254](https://github.com/hdmf-dev/hdmf-zarr/pull/254)
+
 ## 0.10.0 (December 18, 2024)
 
 ### Enhancements

--- a/README.rst
+++ b/README.rst
@@ -6,18 +6,22 @@ hdmf-zarr
 
 The ``hdmf-zarr`` library implements a Zarr backend for HDMF as well as convenience classes for integration of Zarr with PyNWB to support writing of NWB files to Zarr.
 
-**Status:** The Zarr backend is **under development** and may still change. See the `overiew page <https://hdmf-zarr.readthedocs.io/en/latest/overview.html>`_ for an overview of the available features and known limitations of hdmf-zarr.
+**Status:** The Zarr backend is **under development** and may still change. See the `overiew page <https://hdmf-zarr.readthedocs.io/en/stable/overview.html>`_ for an overview of the available features and known limitations of hdmf-zarr.
 
 
-Latest Release
---------------
+Documentation Status
+--------------------
 
-.. image:: https://readthedocs.org/projects/hdmf-zarr/badge/?version=latest
-     :target: https://hdmf-zarr.readthedocs.io/en/latest/?badge=latest
-     :alt: Documentation Status
+Latest release: .. image:: https://readthedocs.org/projects/hdmf-zarr/badge/?version=stable
+     :target: https://hdmf-zarr.readthedocs.io/en/stable/?badge=stable
+     :alt: Documentation status for latest release
+
+Dev branch: .. image:: https://readthedocs.org/projects/hdmf-zarr/badge/?version=dev
+     :target: https://hdmf-zarr.readthedocs.io/en/dev/?badge=dev
+     :alt: Documentation status for dev branch
 
 CI / Health Status
--------------------
+------------------
 
 .. image:: https://codecov.io/gh/hdmf-dev/hdmf-zarr/branch/dev/graph/badge.svg
     :target: https://codecov.io/gh/hdmf-dev/hdmf-zarr
@@ -59,7 +63,7 @@ If you use HDMF or hdmf_zarr in your research, please use the following citation
 Documentation
 -------------
 
-See the ``hdmf-zarr`` documentation for details https://hdmf-zarr.readthedocs.io/en/latest/
+See the ``hdmf-zarr`` documentation for details: https://hdmf-zarr.readthedocs.io
 
 Usage
 -----


### PR DESCRIPTION
## Motivation

- Fix #253. 
- I updated the default RTD to point to "stable" instead of "latest", and I removed the "latest" version. I added an automation rule in RTD to activate the version associated with each tag. I activated versions for the last two tags. Now the possible versions are: "stable", "dev", 0.10.0, and 0.9.0.
- Also removed workflow that automatically generated GitHub pre-releases on each commit to dev to simplify maintenance.
- Also adopted changelog format conventions: https://keepachangelog.com/en/1.0.0/ 

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?