### PR TITLE
Add scipy to test dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # HDMF-ZARR Changelog
 
-## 0.11.0 January 17, 2025
+## [Upcoming]
+
+### Changed
+* Added scipy to optional dependencies to be compatible with HDMF 4.0. @rly [#261](https://github.com/hdmf-dev/hdmf-zarr/pull/261)
+
+## 0.11.0 (January 17, 2025)
 
 ### Changed
 * Adopted changelog format conventions: https://keepachangelog.com/en/1.0.0/ . @rly [#254](https://github.com/hdmf-dev/hdmf-zarr/pull/254)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,9 @@ test = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "python-dateutil",
+    "python-dateutil",  # used in some tests
     "ruff",
+    "scipy",  # used in some tests
     "tox",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ test = [
 # documentation dependencies
 docs = [
     "matplotlib",
+    "scipy",  # used in some docs
     "sphinx>=4",  # improved support for docutils>=0.17
     "sphinx_rtd_theme>=1",  # <1 does not work with docutils>=0.17
     "sphinx-gallery",


### PR DESCRIPTION
## Motivation

Tests are failing because HDMF 4.0 removed scipy as a primary dependency and hdmf-zarr uses scipy in some tests. We need to add it to the test optional dependency group.

## How to test the behavior?
Run tests

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?