### PR TITLE
Fix readme docs badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,15 @@ Support for Zarr v3 is planned. You can track progress of the support in https:/
 Documentation Status
 --------------------
 
-Latest release: .. image:: https://readthedocs.org/projects/hdmf-zarr/badge/?version=stable
+Latest release: 
+
+.. image:: https://readthedocs.org/projects/hdmf-zarr/badge/?version=stable
      :target: https://hdmf-zarr.readthedocs.io/en/stable/?badge=stable
      :alt: Documentation status for latest release
 
-Dev branch: .. image:: https://readthedocs.org/projects/hdmf-zarr/badge/?version=dev
+Dev branch: 
+
+.. image:: https://readthedocs.org/projects/hdmf-zarr/badge/?version=dev
      :target: https://hdmf-zarr.readthedocs.io/en/dev/?badge=dev
      :alt: Documentation status for dev branch
 


### PR DESCRIPTION
The `README.md` is badly formatted:
<img width="833" alt="image" src="https://github.com/user-attachments/assets/98e70d07-c886-4c4d-be49-cf5b5b361f58" />

This PR fixes that:
<img width="252" alt="Screenshot 2025-01-31 at 2 20 59 PM" src="https://github.com/user-attachments/assets/e239e09c-5338-415f-9d94-b816a8be71a7" />
