### PR TITLE
Housekeeping changes to mirror hdmf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 description = "A package defining a Zarr I/O backend for HDMF"
 readme = "README.rst"
 requires-python = ">=3.9"
-license = {text = "BSD"}
+license = "BSD-3-Clause"
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.9",
@@ -29,6 +29,7 @@ classifiers = [
     "Operating System :: Unix",
     "Topic :: Scientific/Engineering :: Medical Science Apps."
 ]
+# make sure to update min-reqs dependencies below when these lower bounds change
 dependencies = [
     "hdmf>=3.14.5",
     "zarr>=2.18.0, <3.0",  # pin below 3.0 until HDMF-zarr supports zarr 3.0
@@ -72,6 +73,18 @@ docs = [
 
 # all possible dependencies
 all = ["hdmf-zarr[full,test,docs]"]
+
+# minimum requirements of project dependencies for testing (see .github/workflows/run_all_tests.yml)
+min-reqs = [
+    "h5py==3.1.0",
+    "jsonschema==3.2.0",
+    "numpy==1.19.3",
+    "pandas==1.2.0",
+    "ruamel.yaml==0.16.0",
+    "scipy==1.7.0",
+    "tqdm==4.41.0",
+    "zarr==2.12.0",
+]
 
 
 [project.urls]
@@ -118,7 +131,7 @@ include = '\.pyi?$'
 force-exclude = 'docs/*'
 
 [tool.ruff]
-lint.select = ["E", "F", "T100", "T201", "T203"]
+lint.select = ["E", "F", "T100", "T201", "T203", "C901"]
 exclude = [
   ".git",
   ".tox",


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.
Update ruff action to non-deprecated one
Update github-app-token action to official github one
Remove requirements-min.txt in favor of an optional dependency group in pyproject.toml and update docs accordingly
Update pyproject.toml license key to correct format
Add back ruff mccabe complexity check which was accidentally removed in transition to ruff
## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [ ] Does the PR clearly describe the problem and the solution?
- [ ] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?