### PR TITLE
Add warning if writing file without `.nwb.zarr` file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 * Added scipy to optional dependencies to be compatible with HDMF 4.0. @rly [#261](https://github.com/hdmf-dev/hdmf-zarr/pull/261)
+* Added warning in NWBZarrIO if writing file name that does not end in ".nwb.zarr". @stephprince [#265](https://github.com/hdmf-dev/hdmf-zarr/pull/265)
 
 ## 0.11.0 (January 17, 2025)
 

--- a/src/hdmf_zarr/nwb.py
+++ b/src/hdmf_zarr/nwb.py
@@ -1,5 +1,6 @@
 """Module with Zarr backend for NWB for integration with PyNWB"""
 
+import warnings
 from pathlib import Path
 from .backend import ZarrIO, SUPPORTED_ZARR_STORES
 
@@ -41,6 +42,10 @@ class NWBZarrIO(ZarrIO):
         io_modes_that_create_file = ["w", "w-", "x"]
         if mode in io_modes_that_create_file or manager is not None or extensions is not None:
             load_namespaces = False
+
+        if mode in io_modes_that_create_file and not str(path).endswith('.nwb.zarr'):
+            warnings.warn(f"The file path provided: {path} does not end in '.nwb.zarr'. "
+                           "It is recommended that NWB files using the Zarr backend use the '.nwb.zarr' extension", UserWarning)
 
         if load_namespaces:
             tm = get_type_map()

--- a/src/hdmf_zarr/nwb.py
+++ b/src/hdmf_zarr/nwb.py
@@ -45,7 +45,8 @@ class NWBZarrIO(ZarrIO):
 
         if mode in io_modes_that_create_file and not str(path).endswith('.nwb.zarr'):
             warnings.warn(f"The file path provided: {path} does not end in '.nwb.zarr'. "
-                           "It is recommended that NWB files using the Zarr backend use the '.nwb.zarr' extension", UserWarning)
+                           "It is recommended that NWB files using the Zarr backend use "
+                           "the '.nwb.zarr' extension", UserWarning)
 
         if load_namespaces:
             tm = get_type_map()

--- a/tests/unit/test_nwbzarrio.py
+++ b/tests/unit/test_nwbzarrio.py
@@ -4,6 +4,9 @@ import os
 import shutil
 from datetime import datetime
 from dateutil.tz import tzlocal
+from pathlib import Path
+
+from hdmf.testing import TestCase
 
 try:
     from pynwb import NWBFile
@@ -14,18 +17,11 @@ except ImportError:
 
 
 @unittest.skipIf(not PYNWB_AVAILABLE, "PyNWB not installed")
-class TestNWBZarrIO(unittest.TestCase):
+class TestNWBZarrIO(TestCase):
 
     def setUp(self):
-        self.filepath = "test_io.zarr"
-
-    def tearDown(self):
-        if os.path.exists(self.filepath):
-            shutil.rmtree(self.filepath)
-
-    def write_test_file(self):
-        # Create the NWBFile
-        nwbfile = NWBFile(
+        self.filepath = "test_io.nwb.zarr"
+        self.nwbfile = NWBFile(
             session_description="my first synthetic recording",
             identifier="EXAMPLE_ID",
             session_start_time=datetime.now(tzlocal()),
@@ -35,11 +31,33 @@ class TestNWBZarrIO(unittest.TestCase):
             experiment_description="I went on an adventure with thirteen dwarves to reclaim vast treasures.",
             session_id="LONELYMTN",
         )
-
         # Create a device
-        nwbfile.create_device(name="array", description="the best array", manufacturer="Probe Company 9000")
+        self.nwbfile.create_device(name="array", description="the best array", manufacturer="Probe Company 9000")
+
+    def tearDown(self):
+        if os.path.exists(self.filepath):
+            shutil.rmtree(self.filepath)
+
+    def write_test_file(self):
         with NWBZarrIO(path=self.filepath, mode="w") as io:
-            io.write(nwbfile)
+            io.write(self.nwbfile)
+
+    def test_file_extension_warning(self):
+        """Test that a warning is raised when the file extension is not .nwb.zarr"""
+        wrong_filepath = Path(self.filepath).with_suffix('.h5')
+
+        msg = (f"The file path provided: {wrong_filepath} does not end in '.nwb.zarr'. "
+                "It is recommended that NWB files using the Zarr backend use the '.nwb.zarr' extension")
+
+        with self.assertWarnsWith(UserWarning, msg):
+            with NWBZarrIO(path=wrong_filepath, mode="w") as io:
+                io.write(self.nwbfile)
+
+        # should not warn on read or append
+        with NWBZarrIO(wrong_filepath, 'r') as io:
+            io.read()
+        with NWBZarrIO(wrong_filepath, 'a') as io:
+            io.read()
 
     def test_read_nwb(self):
         """


### PR DESCRIPTION
## Motivation

Fix #230. Add a warning if writing a Zarr NWBFile that does not end in `.nwb.zarr`.

## How to test the behavior?
```python
from datetime import datetime
from dateutil.tz import tzutc
from pynwb import NWBFile
from hdmf_zarr import NWBZarrIO

nwbfile = NWBFile(session_description='a test NWB File',
                                identifier='TEST123',
                                session_start_time=datetime(1970, 1, 1, 12, tzinfo=tzutc()))
with NWBZarrIO("path.h5", 'w') as io:
    io.write(nwbfile)
```

Warns with:

```
UserWarning: The file path provided: path.h5 does not end in '.nwb.zarr'. It is recommended that NWB files using the Zarr backend use the '.nwb.zarr' extension
  warnings.warn(f"The file path provided: {path} does not end in '.nwb.zarr'. "
```


## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [X] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?