### PR TITLE
Restrict numcodecs dependency to <0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 * Added scipy to optional dependencies to be compatible with HDMF 4.0. @rly [#261](https://github.com/hdmf-dev/hdmf-zarr/pull/261)
+* Restricted numcodecs dependency to <0.16 due to incompatibility with the latest zarr<3 version. @rly [#270](https://github.com/hdmf-dev/hdmf-zarr/pull/270)
 
 ## 0.11.0 (January 17, 2025)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "hdmf>=3.14.5",
     "zarr>=2.18.0, <3.0",  # pin below 3.0 until HDMF-zarr supports zarr 3.0
     "numpy>=1.24.0",
-    "numcodecs>=0.10.0",
+    "numcodecs>=0.10.0, <0.16.0",  # numcodecs 0.16.0 is not compatible with zarr<3
     "pynwb>=2.8.3",
     "threadpoolctl>=3.1.0",
 ]


### PR DESCRIPTION
## Motivation

Fix #269 

## How to test the behavior?
pip install local dev version

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?