### PR TITLE
Prepare for 0.11.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF-ZARR Changelog
 
-## [Upcoming]
+## 0.11.1 (April 8, 2025)
 
 ### Changed
 * Added scipy to optional dependencies to be compatible with HDMF 4.0. @rly [#261](https://github.com/hdmf-dev/hdmf-zarr/pull/261)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,7 +10,7 @@ Install hdmf-zarr from PyPI
 .. code-block::
 
     pip install hdmf-zarr
-    
+
 Install hdmf-zarr from conda-forge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -36,8 +36,7 @@ often useful to use the ``dev`` branch of the ``hdmf`` GitHub repository.
 
     git clone --recurse-submodules https://github.com/hdmf-dev/hdmf.git
     cd hdmf
-    pip install -r requirements.txt -r requirements-dev.txt -r requirements-doc.txt -r requirements-opt.txt
-    pip install -e .
+    pip install -e ".[all]"
     cd ..
 
     git clone https://github.com/hdmf-dev/hdmf-zarr.git
@@ -50,6 +49,3 @@ often useful to use the ``dev`` branch of the ``hdmf`` GitHub repository.
    install HDMF directly from PyPI instead of using the development version of HDMF
    that is already installed. In that case call ``pip uninstall hdmf`` and
    go to the ``hdmf`` directory and run ``pip install -e .`` again
-
-
-


### PR DESCRIPTION
Prepare for release of HDMF-Zarr 0.11.1

### Before merging:
- [x] Make sure all PRs to be included in this release have been merged to `dev`.
- [x] Major and minor releases: Update dependency ranges in `pyproject.toml` and minimums in 
  `requirements-min.txt` as needed.
- [x] Check legal file dates and information in `License.txt`, `README.rst`, `docs/source/conf.py`,
  and any other locations as needed
- [x] Update `pyproject.toml` as needed
- [x] Update `README.rst` as needed
- [x] Update changelog (set release date) in `CHANGELOG.md` and any other docs as needed
- [x] Run tests locally including gallery tests, and inspect all warnings and outputs
  (`pytest && python test_gallery.py`)
- [x] Test docs locally and inspect all warnings and outputs `cd docs; make clean && make html`
- [x] After pushing this branch to GitHub, manually trigger the "Run all tests" GitHub Actions workflow on this
  branch by going to https://github.com/hdmf-dev/hdmf-zarr/actions/workflows/run_all_tests.yml, selecting
  "Run workflow" on the right, selecting this branch, and clicking "Run workflow". Make sure all tests pass.
- [x] Check that the readthedocs build for this PR succeeds (see the PR check)

### After merging:
1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release [tag]` if set up
2. After the CI bot creates the new release (wait ~10 min), update the release notes on the
   [GitHub releases page](https://github.com/hdmf-dev/hdmf-zarr/releases) with the changelog
3. Check that the readthedocs "latest" build runs and succeeds
4. Either monitor [conda-forge/hdmf_zarr-feedstock](https://github.com/conda-forge/hdmf_zarr-feedstock) for the
   regro-cf-autotick-bot bot to create a PR updating the version of HDMF to the latest PyPI release, usually within
   24 hours of release, or manually create a PR updating `recipe/meta.yaml` with the latest version number
   and SHA256 retrieved from PyPI > HDMF-Zarr > Download Files > View hashes for the `.tar.gz` file. Re-render and 
   update the dependencies as needed.
