### PR TITLE
Cache specifications in consolidated metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # HDMF-ZARR Changelog
 
+## Upcoming
+
+### Bug Fixes
+* Fix saving of the cached specs in the consolidated metadata. @stephprince [#274](https://github.com/hdmf-dev/hdmf-zarr/pull/274)
+
 ## 0.11.1 (April 8, 2025)
 
 ### Changed
 * Added scipy to optional dependencies to be compatible with HDMF 4.0. @rly [#261](https://github.com/hdmf-dev/hdmf-zarr/pull/261)
 * Restricted numcodecs dependency to <0.16 due to incompatibility with the latest zarr<3 version. @rly [#270](https://github.com/hdmf-dev/hdmf-zarr/pull/270)
-
-### Bug Fixes
-* Fix saving of the cached specs in the consolidated metadata. @stephprince [#274](https://github.com/hdmf-dev/hdmf-zarr/pull/274)
 
 ## 0.11.0 (January 17, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Added scipy to optional dependencies to be compatible with HDMF 4.0. @rly [#261](https://github.com/hdmf-dev/hdmf-zarr/pull/261)
 * Restricted numcodecs dependency to <0.16 due to incompatibility with the latest zarr<3 version. @rly [#270](https://github.com/hdmf-dev/hdmf-zarr/pull/270)
 
+### Bug Fixes
+* Fix saving of the cached specs in the consolidated metadata. @stephprince [#274](https://github.com/hdmf-dev/hdmf-zarr/pull/274)
+
 ## 0.11.0 (January 17, 2025)
 
 ### Changed

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -334,7 +334,8 @@ class ZarrIO(HDMFIO):
     def write(self, **kwargs):
         """Overwrite the write method to add support for caching the specification and parallelization."""
         cache_spec, number_of_jobs, max_threads_per_process, multiprocessing_context, consolidate_metadata = popargs(
-            "cache_spec", "number_of_jobs", "max_threads_per_process", "multiprocessing_context", "consolidate_metadata", kwargs
+            "cache_spec", "number_of_jobs", "max_threads_per_process", "multiprocessing_context", 
+            "consolidate_metadata", kwargs
         )
 
         self.__dci_queue = ZarrIODataChunkIteratorQueue(

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -333,8 +333,8 @@ class ZarrIO(HDMFIO):
     )
     def write(self, **kwargs):
         """Overwrite the write method to add support for caching the specification and parallelization."""
-        cache_spec, number_of_jobs, max_threads_per_process, multiprocessing_context = popargs(
-            "cache_spec", "number_of_jobs", "max_threads_per_process", "multiprocessing_context", kwargs
+        cache_spec, number_of_jobs, max_threads_per_process, multiprocessing_context, consolidate_metadata = popargs(
+            "cache_spec", "number_of_jobs", "max_threads_per_process", "multiprocessing_context", "consolidate_metadata", kwargs
         )
 
         self.__dci_queue = ZarrIODataChunkIteratorQueue(
@@ -346,6 +346,10 @@ class ZarrIO(HDMFIO):
         super(ZarrIO, self).write(**kwargs)
         if cache_spec:
             self.__cache_spec()
+
+        # Reconsolidate metadata after the spec has been cached
+        if consolidate_metadata:
+            zarr.consolidate_metadata(store=self.path)
 
     def __cache_spec(self):
         """Internal function used to cache the spec in the current file"""

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -13,7 +13,7 @@ import warnings
 # Try to import Zarr and disable tests if Zarr is not available
 import zarr
 from hdmf_zarr.backend import ZarrIO
-from hdmf_zarr.utils import ZarrDataIO, ZarrReference, ZarrSpecReader
+from hdmf_zarr.utils import ZarrDataIO, ZarrReference
 from tests.unit.utils import Baz, BazData, BazBucket, get_baz_buildmanager
 
 # Try to import numcodecs and disable compression tests if it is not available

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -13,7 +13,7 @@ import warnings
 # Try to import Zarr and disable tests if Zarr is not available
 import zarr
 from hdmf_zarr.backend import ZarrIO
-from hdmf_zarr.utils import ZarrDataIO, ZarrReference
+from hdmf_zarr.utils import ZarrDataIO, ZarrReference, ZarrSpecReader
 from tests.unit.utils import Baz, BazData, BazBucket, get_baz_buildmanager
 
 # Try to import numcodecs and disable compression tests if it is not available
@@ -236,6 +236,31 @@ class BaseTestZarrWriter(BaseZarrWriterTestCase):
         tempIO.write(foofile, cache_spec=True)
         tempIO.close()
 
+        # Load the spec and assert that it is valid
+        ns_catalog = NamespaceCatalog()
+        ZarrIO.load_namespaces(ns_catalog, self.store_path)
+        self.assertEqual(ns_catalog.namespaces, ("test_core",))
+        source_types = CacheSpecTestHelper.get_types(self.manager.namespace_catalog)
+        read_types = CacheSpecTestHelper.get_types(ns_catalog)
+        self.assertSetEqual(source_types, read_types)
+    
+    def test_cache_spec_consolidated(self):
+        tempIO = ZarrIO(self.store_path, manager=self.manager, mode="w")
+
+        # Setup all the data we need
+        foo1 = Foo("foo1", [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
+        foo2 = Foo("foo2", [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
+        foobucket = FooBucket("test_bucket", [foo1, foo2])
+        foofile = FooFile(buckets=[foobucket])
+
+        # Write the first file
+        tempIO.write(foofile, cache_spec=True, consolidate_metadata=True)
+        tempIO.close()
+
+        # Check that the spec is cached
+        readIO = ZarrIO(self.store_path, manager=self.manager, mode="r")
+        self.assertIn('.specloc', readIO.file.attrs.keys())
+        
         # Load the spec and assert that it is valid
         ns_catalog = NamespaceCatalog()
         ZarrIO.load_namespaces(ns_catalog, self.store_path)


### PR DESCRIPTION
## Motivation

Fix #243. 

Reconsolidate metadata after the specifications are cached so the specifications can be accessed when using consolidated metadata.

## How to test the behavior?

See steps to reproduce in the original issue.

## Checklist

- [X] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [X] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?