### PR TITLE
Writing Compound Dtype Dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 * Fix saving of the cached specs in the consolidated metadata. @stephprince [#274](https://github.com/hdmf-dev/hdmf-zarr/pull/274)
+* Correctly write a compound dataset. @mavaylon1 [276](https://github.com/hdmf-dev/hdmf-zarr/pull/276)
 
 ## 0.11.1 (April 8, 2025)
 

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -334,7 +334,7 @@ class ZarrIO(HDMFIO):
     def write(self, **kwargs):
         """Overwrite the write method to add support for caching the specification and parallelization."""
         cache_spec, number_of_jobs, max_threads_per_process, multiprocessing_context, consolidate_metadata = popargs(
-            "cache_spec", "number_of_jobs", "max_threads_per_process", "multiprocessing_context", 
+            "cache_spec", "number_of_jobs", "max_threads_per_process", "multiprocessing_context",
             "consolidate_metadata", kwargs
         )
 
@@ -1397,7 +1397,7 @@ class ZarrIO(HDMFIO):
         # standard write
         else:
             try:
-                dset[:] = np.array(data)
+                dset[:] = np.array(data, dtype=dtype)
             # If data is an h5py.Dataset then this will copy the data
             # For compound data types containing strings Zarr sometimes does not like writing multiple values
             # try to write them one-at-a-time instead then

--- a/tests/unit/test_nwbzarrio.py
+++ b/tests/unit/test_nwbzarrio.py
@@ -4,9 +4,13 @@ import os
 import shutil
 from datetime import datetime
 from dateutil.tz import tzlocal
+import numpy as np
 
 try:
     from pynwb import NWBFile
+    from pynwb.ophys import PlaneSegmentation
+    from pynwb.testing.mock.file import mock_NWBFile
+    from pynwb.testing.mock.ophys import mock_ImagingPlane
 
     PYNWB_AVAILABLE = True
 except ImportError:
@@ -52,3 +56,39 @@ class TestNWBZarrIO(unittest.TestCase):
         nwbfile = NWBZarrIO.read_nwb(path=self.filepath)
         self.assertEqual(len(nwbfile.devices), 1)
         self.assertTupleEqual(nwbfile.experimenter, ("Dr. Bilbo Baggins",))
+
+class TestNWBZarrIOCompoundDtype(unittest.TestCase):
+    def setUp(self):
+        self.filepath = "test_io.zarr"
+
+    def tearDown(self):
+        if os.path.exists(self.filepath):
+            shutil.rmtree(self.filepath)
+
+    def test_write_dataset_compound_dtype(self):
+        # Create a mock NWB file with pixel_mask PlaneSegmentation
+        nwbfile = mock_NWBFile()
+        n_rois = 10
+        plane_segmentation = PlaneSegmentation(
+            description="no description.",
+            imaging_plane=mock_ImagingPlane(nwbfile=nwbfile),
+            name="PlaneSegmentation",
+        )
+        for _ in range(n_rois):
+            pixel_mask = [(x, x, 1.0) for x in range(10)]
+            plane_segmentation.add_roi(pixel_mask=pixel_mask)
+        if "ophys" not in nwbfile.processing:
+            nwbfile.create_processing_module("ophys", "ophys")
+        nwbfile.processing["ophys"].add(plane_segmentation)
+
+        # write it to disk
+        with NWBZarrIO(self.filepath, "w") as read_io:
+            read_io.write(nwbfile)
+
+        # read it back
+        with NWBZarrIO(self.filepath, "r") as read_io:
+            nwbfile = read_io.read()
+            expected_dtype = np.dtype([('x', '<u4'), ('y', '<u4'), ('weight', '<f4')])
+            actual_dtype = nwbfile.processing["ophys"].data_interfaces['PlaneSegmentation'].pixel_mask.data.dtype
+
+            self.assertEqual(actual_dtype.descr, expected_dtype.descr)

--- a/tests/unit/test_nwbzarrio.py
+++ b/tests/unit/test_nwbzarrio.py
@@ -57,6 +57,8 @@ class TestNWBZarrIO(unittest.TestCase):
         self.assertEqual(len(nwbfile.devices), 1)
         self.assertTupleEqual(nwbfile.experimenter, ("Dr. Bilbo Baggins",))
 
+
+@unittest.skipIf(not PYNWB_AVAILABLE, "PyNWB not installed")
 class TestNWBZarrIOCompoundDtype(unittest.TestCase):
     def setUp(self):
         self.filepath = "test_io.zarr"


### PR DESCRIPTION
Fix #272 
The issue is not export, but correctly writing a compound array. We need to make sure we define the dtype in the array on write. 

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?