### PR TITLE
Add ZarrDataIO.get_io_params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Upcoming
 
+### Changed
+* Added `ZarrDataIO.get_io_params`. @rly [#282](https://github.com/hdmf-dev/hdmf-zarr/pull/282)
+
 ### Bug Fixes
-* Fix saving of the cached specs in the consolidated metadata. @stephprince [#274](https://github.com/hdmf-dev/hdmf-zarr/pull/274)
+* Fixed saving of the cached specs in the consolidated metadata. @stephprince [#274](https://github.com/hdmf-dev/hdmf-zarr/pull/274)
 * Correctly write a compound dataset. @mavaylon1 [276](https://github.com/hdmf-dev/hdmf-zarr/pull/276)
 * Fixed pixel mask data shape expansion bug in __list_fill__ method that was incorrectly duplicating compound data type values during export operations. @pauladkisson [280](https://github.com/hdmf-dev/hdmf-zarr/pull/280)
 

--- a/docs/gallery/plot_nwb_zarrio.py
+++ b/docs/gallery/plot_nwb_zarrio.py
@@ -47,7 +47,7 @@ nwbfile = NWBFile(
 
 # Create a device
 device = nwbfile.create_device(
-    name="array", description="the best array", manufacturer="Probe Company 9000"
+    name="array", description="the best array",
 )
 
 # Add electrodes and electrode groups to the NWB file

--- a/src/hdmf_zarr/utils.py
+++ b/src/hdmf_zarr/utils.py
@@ -494,6 +494,14 @@ class ZarrDataIO(DataIO):
         """Dict with the io settings to use"""
         return self.__iosettings
 
+    def get_io_params(self) -> dict:
+        """
+        Returns a dict with the I/O parameters specified in this DataIO.
+        """
+        ret = dict(self.__iosettings)
+        ret['link_data'] = self.__link_data
+        return ret
+
     @staticmethod
     def from_h5py_dataset(h5dataset, **kwargs):
         """

--- a/tests/unit/test_nwbzarrio.py
+++ b/tests/unit/test_nwbzarrio.py
@@ -41,7 +41,7 @@ class TestNWBZarrIO(unittest.TestCase):
         )
 
         # Create a device
-        nwbfile.create_device(name="array", description="the best array", manufacturer="Probe Company 9000")
+        nwbfile.create_device(name="array", description="the best array")
         with NWBZarrIO(path=self.filepath, mode="w") as io:
             io.write(nwbfile)
 

--- a/tests/unit/test_zarrdataio.py
+++ b/tests/unit/test_zarrdataio.py
@@ -257,6 +257,6 @@ class TestZarrDataIO(TestCase):
         h5file.close()
 
     def test_zarr_data_io_get_io_params(self):
-        z = zarr.array(shape=(10000, 10000), chunks=(1000, 1000), dtype='int32')
+        z = zarr.zeros(shape=(10000, 10000), chunks=(1000, 1000), dtype='int32')
         io = ZarrDataIO(z, link_data=True)
         assert io.get_io_params().get("link_data")

--- a/tests/unit/test_zarrdataio.py
+++ b/tests/unit/test_zarrdataio.py
@@ -257,7 +257,6 @@ class TestZarrDataIO(TestCase):
         h5file.close()
 
     def test_zarr_data_io_get_io_params(self):
-        store = zarr.storage.MemoryStore()
-        z = zarr.create_array(store=store, shape=(10000, 10000), chunks=(1000, 1000), dtype='int32')
+        z = zarr.array(shape=(10000, 10000), chunks=(1000, 1000), dtype='int32')
         io = ZarrDataIO(z, link_data=True)
         assert io.get_io_params().get("link_data")

--- a/tests/unit/test_zarrdataio.py
+++ b/tests/unit/test_zarrdataio.py
@@ -12,6 +12,7 @@ import h5py
 import os
 import shutil
 import unittest
+import zarr
 
 import numpy as np
 
@@ -254,3 +255,9 @@ class TestZarrDataIO(TestCase):
         self.assertEqual(re_zarrdataio.io_settings["fill_value"], str("None"))
         # Close the HDF5 file
         h5file.close()
+
+    def test_zarr_data_io_get_io_params(self):
+        store = zarr.storage.MemoryStore()
+        z = zarr.create_array(store=store, shape=(10000, 10000), chunks=(1000, 1000), dtype='int32')
+        io = ZarrDataIO(z, link_data=True)
+        assert io.get_io_params().get("link_data")


### PR DESCRIPTION
## Motivation

H5DataIO has a method [`get_io_params`](https://github.com/hdmf-dev/hdmf/blob/dev/src/hdmf/backends/hdf5/h5_utils.py#L522) that adds the link_data property to the io settings for construction of a new H5DataIO object with those combined parameters. In https://github.com/hdmf-dev/hdmf/pull/1297, we need the same functionality for ZarrDataIO.

## How to test the behavior?
```
pytest
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?