### PR TITLE
Test if changing default codec to JSON would work

### DIFF
--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -97,7 +97,7 @@ class ZarrIO(HDMFIO):
             "type": None,
             "doc": (
                 "Set the numcodec object codec class to be used to encode objects."
-                "Use numcodecs.pickles.Pickle by default."
+                "Use numcodecs.json.JSON by default."
             ),
             "default": None,
         },
@@ -150,7 +150,7 @@ class ZarrIO(HDMFIO):
         self._written_builders = WriteStatusTracker()  # track which builders were written (or read) by this IO object
         self.__dci_queue = None  # Will be initialized on call to io.write
         # Codec class to be used. Alternates, e.g., =numcodecs.JSON
-        self.__codec_cls = numcodecs.pickles.Pickle if object_codec_class is None else object_codec_class
+        self.__codec_cls = numcodecs.json.JSON if object_codec_class is None else object_codec_class
         source_path = self.__path
         if isinstance(self.__path, SUPPORTED_ZARR_STORES):
             source_path = self.__path.path

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -18,7 +18,7 @@ from tests.unit.utils import Baz, BazData, BazBucket, get_baz_buildmanager
 
 # Try to import numcodecs and disable compression tests if it is not available
 try:
-    from numcodecs import Blosc, Delta, JSON
+    from numcodecs import Blosc, Delta, JSON, Pickle
 
     DISABLE_ZARR_COMPRESSION_TESTS = False
 except ImportError:
@@ -517,12 +517,12 @@ class BaseTestZarrWriteUnit(BaseZarrWriterTestCase):
     #  ZarrDataIO general
     #############################################
     def test_set_object_codec(self):
-        # Test that the default codec is the Pickle store
+        # Test that the default codec is the JSON store
         tempIO = ZarrIO(self.store_path, mode="w")
-        self.assertEqual(tempIO.object_codec_class.__qualname__, "Pickle")
-        del tempIO  # also calls tempIO.close()
-        tempIO = ZarrIO(self.store_path, mode="w", object_codec_class=JSON)
         self.assertEqual(tempIO.object_codec_class.__qualname__, "JSON")
+        del tempIO  # also calls tempIO.close()
+        tempIO = ZarrIO(self.store_path, mode="w", object_codec_class=Pickle)
+        self.assertEqual(tempIO.object_codec_class.__qualname__, "Pickle")
         tempIO.close()
 
     def test_synchronizer_constructor_arg_bool(self):

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -18,7 +18,7 @@ from tests.unit.utils import Baz, BazData, BazBucket, get_baz_buildmanager
 
 # Try to import numcodecs and disable compression tests if it is not available
 try:
-    from numcodecs import Blosc, Delta, JSON, Pickle
+    from numcodecs import Blosc, Delta, Pickle
 
     DISABLE_ZARR_COMPRESSION_TESTS = False
 except ImportError:


### PR DESCRIPTION
## Motivation

See #285 The goal is to see if `JSON` codec works with the types that we need to support. 

- [X] Change default codec in `ZarrIO` to JSON
- [ ] Remove the `object_codec_class` option from `NWBZarrIO` 


## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [ ] Does the PR clearly describe the problem and the solution?
- [ ] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?