### PR TITLE
Drop support for Python 3.9, add support for 3.14

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,11 +53,12 @@ body:
     attributes:
       label: Python Version
       options:
+        - "3.14"
         - "3.13"
         - "3.12"
         - "3.11"
         - "3.10"
-        - "3.9"
+        - older (please specify in "Package Versions" below)
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/HDMF_dev.yaml
+++ b/.github/workflows/HDMF_dev.yaml
@@ -13,16 +13,16 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0  # tags are required to determine the version
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install HDMF_Zarr Requirements
         run: |
           python -m pip install ".[test]"
-          
+
       - name: Clone and Install HDMF Dev Branch
         run: |
           git clone https://github.com/hdmf-dev/hdmf.git --recurse-submodules

--- a/.github/workflows/check_external_links.yml
+++ b/.github/workflows/check_external_links.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install Sphinx dependencies and package
         run: |

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -47,7 +47,7 @@ jobs:
           - { name: macos-python3.12             , test-tox-env: py312           , python-ver: "3.12", os: macos-latest }
           - { name: macos-python3.13             , test-tox-env: py313           , python-ver: "3.13", os: macos-latest }
           - { name: macos-python3.13-optional    , test-tox-env: py313-optional  , python-ver: "3.13", os: macos-latest }
-          - { name: macos-python3.13-prerelease  , test-tox-env: py313-prerelease, python-ver: "3.13", os: macos-latest }          
+          - { name: macos-python3.13-prerelease  , test-tox-env: py313-prerelease, python-ver: "3.13", os: macos-latest }
           # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest
           # So testing on macos-latest (arm64) is disabled. See https://github.com/hdmf-dev/hdmf-zarr/pull/298
           # - { name: macos-python3.14             , test-tox-env: py314           , python-ver: "3.14", os: macos-latest }

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -25,27 +25,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.9-minimum      , test-tox-env: py39-minimum    , python-ver: "3.9" , os: ubuntu-latest }
+          - { name: linux-python3.10-minimum     , test-tox-env: py310-minimum   , python-ver: "3.10", os: ubuntu-latest }
           - { name: linux-python3.10             , test-tox-env: py310           , python-ver: "3.10", os: ubuntu-latest }
           - { name: linux-python3.11             , test-tox-env: py311           , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-python3.12             , test-tox-env: py312           , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-python3.13             , test-tox-env: py313           , python-ver: "3.13", os: ubuntu-latest }
-          - { name: linux-python3.13-optional    , test-tox-env: py313-optional  , python-ver: "3.13", os: ubuntu-latest }
-          - { name: linux-python3.13-prerelease  , test-tox-env: py313-prerelease, python-ver: "3.13", os: ubuntu-latest }
-          - { name: windows-python3.9-minimum    , test-tox-env: py39-minimum    , python-ver: "3.9" , os: windows-latest }
+          - { name: linux-python3.14             , test-tox-env: py314           , python-ver: "3.14", os: ubuntu-latest }
+          - { name: linux-python3.14-optional    , test-tox-env: py314-optional  , python-ver: "3.14", os: ubuntu-latest }
+          - { name: linux-python3.14-prerelease  , test-tox-env: py314-prerelease, python-ver: "3.14", os: ubuntu-latest }
+          - { name: windows-python3.10-minimum   , test-tox-env: py310-minimum   , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.10           , test-tox-env: py310           , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.11           , test-tox-env: py311           , python-ver: "3.11", os: windows-latest }
-          - { name: windows-python3.12           , test-tox-env: py312           , python-ver: "3.12", os: windows-latest } 
-          - { name: windows-python3.13           , test-tox-env: py313           , python-ver: "3.13", os: windows-latest } 
-          - { name: windows-python3.13-optional  , test-tox-env: py313-optional  , python-ver: "3.13", os: windows-latest }
-          - { name: windows-python3.13-prerelease, test-tox-env: py313-prerelease, python-ver: "3.13", os: windows-latest }
-          - { name: macos-python3.9-minimum      , test-tox-env: py39-minimum    , python-ver: "3.9" , os: macos-latest }
+          - { name: windows-python3.12           , test-tox-env: py312           , python-ver: "3.12", os: windows-latest }
+          - { name: windows-python3.13           , test-tox-env: py313           , python-ver: "3.13", os: windows-latest }
+          - { name: windows-python3.14           , test-tox-env: py314           , python-ver: "3.14", os: windows-latest }
+          - { name: windows-python3.14-optional  , test-tox-env: py314-optional  , python-ver: "3.14", os: windows-latest }
+          - { name: windows-python3.14-prerelease, test-tox-env: py314-prerelease, python-ver: "3.14", os: windows-latest }
+          - { name: macos-python3.10-minimum     , test-tox-env: py310-minimum   , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.10             , test-tox-env: py310           , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.11             , test-tox-env: py311           , python-ver: "3.11", os: macos-latest }
           - { name: macos-python3.12             , test-tox-env: py312           , python-ver: "3.12", os: macos-latest }
           - { name: macos-python3.13             , test-tox-env: py313           , python-ver: "3.13", os: macos-latest }
-          - { name: macos-python3.13-optional    , test-tox-env: py313-optional  , python-ver: "3.13", os: macos-latest }
-          - { name: macos-python3.13-prerelease  , test-tox-env: py313-prerelease, python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.14             , test-tox-env: py314           , python-ver: "3.14", os: macos-latest }
+          - { name: macos-python3.14-optional    , test-tox-env: py314-optional  , python-ver: "3.14", os: macos-latest }
+          - { name: macos-python3.14-prerelease  , test-tox-env: py314-prerelease, python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -79,7 +82,7 @@ jobs:
       - name: Test installation from a source distribution
         run: |
           tox -e wheelinstall --recreate --installpkg dist/*.tar.gz
-        
+
   run-all-gallery-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -93,15 +96,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-gallery-python3.9-minimum      , test-tox-env: gallery-py39-minimum    , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-gallery-python3.13-optional    , test-tox-env: gallery-py313-optional  , python-ver: "3.13", os: ubuntu-latest }
-          - { name: linux-gallery-python3.13-prerelease  , test-tox-env: gallery-py313-prerelease, python-ver: "3.13", os: ubuntu-latest }
-          - { name: windows-gallery-python3.9-minimum    , test-tox-env: gallery-py39-minimum    , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-gallery-python3.13-optional  , test-tox-env: gallery-py313-optional  , python-ver: "3.13", os: windows-latest }
-          - { name: windows-gallery-python3.13-prerelease, test-tox-env: gallery-py313-prerelease, python-ver: "3.13", os: windows-latest }
-          - { name: macos-gallery-python3.9-minimum      , test-tox-env: gallery-py39-minimum    , python-ver: "3.9" , os: macos-latest }
-          - { name: macos-gallery-python3.13-optional    , test-tox-env: gallery-py313-optional  , python-ver: "3.13", os: macos-latest }
-          - { name: macos-gallery-python3.13-prerelease  , test-tox-env: gallery-py313-prerelease, python-ver: "3.13", os: macos-latest }
+          - { name: linux-gallery-python3.10-minimum     , test-tox-env: gallery-py310-minimum   , python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-gallery-python3.14-optional    , test-tox-env: gallery-py314-optional  , python-ver: "3.14", os: ubuntu-latest }
+          - { name: linux-gallery-python3.14-prerelease  , test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: ubuntu-latest }
+          - { name: windows-gallery-python3.10-minimum   , test-tox-env: gallery-py310-minimum   , python-ver: "3.10", os: windows-latest }
+          - { name: windows-gallery-python3.14-optional  , test-tox-env: gallery-py314-optional  , python-ver: "3.14", os: windows-latest }
+          - { name: windows-gallery-python3.14-prerelease, test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: windows-latest }
+          - { name: macos-gallery-python3.10-minimum     , test-tox-env: gallery-py310-minimum   , python-ver: "3.10", os: macos-latest }
+          - { name: macos-gallery-python3.14-optional    , test-tox-env: gallery-py314-optional  , python-ver: "3.14", os: macos-latest }
+          - { name: macos-gallery-python3.14-prerelease  , test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -136,13 +139,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.9-minimum    , test-tox-env: py39-minimum    , python-ver: "3.9" , os: ubuntu-latest }
+          - { name: conda-linux-python3.10-minimum   , test-tox-env: py310-minimum   , python-ver: "3.10", os: ubuntu-latest }
           - { name: conda-linux-python3.10           , test-tox-env: py310           , python-ver: "3.10", os: ubuntu-latest }
           - { name: conda-linux-python3.11           , test-tox-env: py311           , python-ver: "3.11", os: ubuntu-latest }
-          - { name: conda-linux-python3.12           , test-tox-env: py312           , python-ver: "3.12", os: ubuntu-latest }  
-          - { name: conda-linux-python3.13           , test-tox-env: py313           , python-ver: "3.13", os: ubuntu-latest }          
-          - { name: conda-linux-python3.13-optional  , test-tox-env: py313-optional  , python-ver: "3.13", os: ubuntu-latest }
-          - { name: conda-linux-python3.13-prerelease, test-tox-env: py313-prerelease, python-ver: "3.13", os: ubuntu-latest }
+          - { name: conda-linux-python3.12           , test-tox-env: py312           , python-ver: "3.12", os: ubuntu-latest }
+          - { name: conda-linux-python3.13           , test-tox-env: py313           , python-ver: "3.13", os: ubuntu-latest }
+          - { name: conda-linux-python3.14           , test-tox-env: py314           , python-ver: "3.14", os: ubuntu-latest }
+          - { name: conda-linux-python3.14-optional  , test-tox-env: py314-optional  , python-ver: "3.14", os: ubuntu-latest }
+          - { name: conda-linux-python3.14-prerelease, test-tox-env: py314-prerelease, python-ver: "3.14", os: ubuntu-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -182,7 +186,7 @@ jobs:
       - name: Test installation from a wheel
         run: |
           tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
-      
+
       - name: Test installation from a source distribution
         run: |
           tox -e wheelinstall --recreate --installpkg dist/*.tar.gz

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -50,9 +50,9 @@ jobs:
           - { name: macos-python3.13-prerelease  , test-tox-env: py313-prerelease, python-ver: "3.13", os: macos-latest }          
           # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest
           # So testing on macos-latest (arm64) is disabled. See https://github.com/hdmf-dev/hdmf-zarr/pull/298
-          - { name: macos-python3.14             , test-tox-env: py314           , python-ver: "3.14", os: macos-latest }
-          - { name: macos-python3.14-optional    , test-tox-env: py314-optional  , python-ver: "3.14", os: macos-latest }
-          - { name: macos-python3.14-prerelease  , test-tox-env: py314-prerelease, python-ver: "3.14", os: macos-latest }
+          # - { name: macos-python3.14             , test-tox-env: py314           , python-ver: "3.14", os: macos-latest }
+          # - { name: macos-python3.14-optional    , test-tox-env: py314-optional  , python-ver: "3.14", os: macos-latest }
+          # - { name: macos-python3.14-prerelease  , test-tox-env: py314-prerelease, python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -111,8 +111,8 @@ jobs:
           - { name: macos-gallery-python3.13-prerelease  , test-tox-env: gallery-py313-prerelease, python-ver: "3.13", os: macos-latest }
           # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest
           # So testing on macos-latest (arm64) is disabled. See https://github.com/hdmf-dev/hdmf-zarr/pull/298
-          - { name: macos-gallery-python3.14-optional    , test-tox-env: gallery-py314-optional  , python-ver: "3.14", os: macos-latest }
-          - { name: macos-gallery-python3.14-prerelease  , test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: macos-latest }
+          # - { name: macos-gallery-python3.14-optional    , test-tox-env: gallery-py314-optional  , python-ver: "3.14", os: macos-latest }
+          # - { name: macos-gallery-python3.14-prerelease  , test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -41,11 +41,15 @@ jobs:
           - { name: windows-python3.14           , test-tox-env: py314           , python-ver: "3.14", os: windows-latest }
           - { name: windows-python3.14-optional  , test-tox-env: py314-optional  , python-ver: "3.14", os: windows-latest }
           - { name: windows-python3.14-prerelease, test-tox-env: py314-prerelease, python-ver: "3.14", os: windows-latest }
-          - { name: macos-python3.10-minimum     , test-tox-env: py310-minimum   , python-ver: "3.10", os: macos-latest }
+          - { name: macos-python3.10-minimum     , test-tox-env: py310-minimum   , python-ver: "3.10", os: macos-13 }
           - { name: macos-python3.10             , test-tox-env: py310           , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.11             , test-tox-env: py311           , python-ver: "3.11", os: macos-latest }
           - { name: macos-python3.12             , test-tox-env: py312           , python-ver: "3.12", os: macos-latest }
           - { name: macos-python3.13             , test-tox-env: py313           , python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.13-optional    , test-tox-env: py313-optional  , python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.13-prerelease  , test-tox-env: py313-prerelease, python-ver: "3.13", os: macos-latest }          
+          # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest
+          # So testing on macos-latest (arm64) is disabled. See https://github.com/hdmf-dev/hdmf-zarr/pull/298
           - { name: macos-python3.14             , test-tox-env: py314           , python-ver: "3.14", os: macos-latest }
           - { name: macos-python3.14-optional    , test-tox-env: py314-optional  , python-ver: "3.14", os: macos-latest }
           - { name: macos-python3.14-prerelease  , test-tox-env: py314-prerelease, python-ver: "3.14", os: macos-latest }
@@ -102,7 +106,11 @@ jobs:
           - { name: windows-gallery-python3.10-minimum   , test-tox-env: gallery-py310-minimum   , python-ver: "3.10", os: windows-latest }
           - { name: windows-gallery-python3.14-optional  , test-tox-env: gallery-py314-optional  , python-ver: "3.14", os: windows-latest }
           - { name: windows-gallery-python3.14-prerelease, test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: windows-latest }
-          - { name: macos-gallery-python3.10-minimum     , test-tox-env: gallery-py310-minimum   , python-ver: "3.10", os: macos-latest }
+          - { name: macos-gallery-python3.10-minimum     , test-tox-env: gallery-py310-minimum   , python-ver: "3.10", os: macos-13 }
+          - { name: macos-gallery-python3.13-optional    , test-tox-env: gallery-py313-optional  , python-ver: "3.13", os: macos-latest }
+          - { name: macos-gallery-python3.13-prerelease  , test-tox-env: gallery-py313-prerelease, python-ver: "3.13", os: macos-latest }
+          # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest
+          # So testing on macos-latest (arm64) is disabled. See https://github.com/hdmf-dev/hdmf-zarr/pull/298
           - { name: macos-gallery-python3.14-optional    , test-tox-env: gallery-py314-optional  , python-ver: "3.14", os: macos-latest }
           - { name: macos-gallery-python3.14-prerelease  , test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: macos-latest }
     steps:

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -28,7 +28,8 @@ jobs:
           - { os: macos-latest  , opt_req: false }
     env:  # used by codecov-action
       OS: ${{ matrix.os }}
-      PYTHON: '3.14'
+      # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest
+      PYTHON: '3.13'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -28,7 +28,7 @@ jobs:
           - { os: macos-latest  , opt_req: false }
     env:  # used by codecov-action
       OS: ${{ matrix.os }}
-      PYTHON: '3.13'
+      PYTHON: '3.14'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,9 +25,13 @@ jobs:
           - { name: windows-python3.10-minimum , test-tox-env: py310-minimum , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.14         , test-tox-env: py314         , python-ver: "3.14", os: windows-latest }
           - { name: windows-python3.14-optional, test-tox-env: py314-optional, python-ver: "3.14", os: windows-latest }
-          - { name: macos-python3.10-minimum   , test-tox-env: py310-minimum , python-ver: "3.10", os: macos-latest }
-          - { name: macos-python3.14           , test-tox-env: py314         , python-ver: "3.14", os: macos-latest }
-          - { name: macos-python3.14-optional  , test-tox-env: py314-optional, python-ver: "3.14", os: macos-latest }
+          - { name: macos-python3.10-minimum   , test-tox-env: py310-minimum , python-ver: "3.10", os: macos-13 }
+          - { name: macos-python3.13           , test-tox-env: py313         , python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.13-optional  , test-tox-env: py313-optional, python-ver: "3.13", os: macos-latest }
+          # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest
+          # So testing on macos-latest (arm64) is disabled. See https://github.com/hdmf-dev/hdmf-zarr/pull/298
+          # - { name: macos-python3.14           , test-tox-env: py314         , python-ver: "3.14", os: macos-latest }
+          # - { name: macos-python3.14-optional  , test-tox-env: py314-optional, python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,15 +19,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.9-minimum    , test-tox-env: py39-minimum  , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-python3.13           , test-tox-env: py313         , python-ver: "3.13", os: ubuntu-latest }
-          - { name: linux-python3.13-optional  , test-tox-env: py313-optional, python-ver: "3.13", os: ubuntu-latest }
-          - { name: windows-python3.9-minimum  , test-tox-env: py39-minimum  , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-python3.13         , test-tox-env: py313         , python-ver: "3.13", os: windows-latest }
-          - { name: windows-python3.13-optional, test-tox-env: py313-optional, python-ver: "3.13", os: windows-latest }
-          - { name: macos-python3.9-minimum    , test-tox-env: py39-minimum  , python-ver: "3.9" , os: macos-latest }
-          - { name: macos-python3.13           , test-tox-env: py313         , python-ver: "3.13", os: macos-latest }
-          - { name: macos-python3.13-optional  , test-tox-env: py313-optional, python-ver: "3.13", os: macos-latest }
+          - { name: linux-python3.10-minimum   , test-tox-env: py310-minimum , python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-python3.14           , test-tox-env: py314         , python-ver: "3.14", os: ubuntu-latest }
+          - { name: linux-python3.14-optional  , test-tox-env: py314-optional, python-ver: "3.14", os: ubuntu-latest }
+          - { name: windows-python3.10-minimum , test-tox-env: py310-minimum , python-ver: "3.10", os: windows-latest }
+          - { name: windows-python3.14         , test-tox-env: py314         , python-ver: "3.14", os: windows-latest }
+          - { name: windows-python3.14-optional, test-tox-env: py314-optional, python-ver: "3.14", os: windows-latest }
+          - { name: macos-python3.10-minimum   , test-tox-env: py310-minimum , python-ver: "3.10", os: macos-latest }
+          - { name: macos-python3.14           , test-tox-env: py314         , python-ver: "3.14", os: macos-latest }
+          - { name: macos-python3.14-optional  , test-tox-env: py314-optional, python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -75,10 +75,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-gallery-python3.9-minimum    , test-tox-env: gallery-py39-minimum  , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-gallery-python3.13-optional  , test-tox-env: gallery-py313-optional, python-ver: "3.13", os: ubuntu-latest }
-          - { name: windows-gallery-python3.9-minimum  , test-tox-env: gallery-py39-minimum  , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-gallery-python3.13-optional, test-tox-env: gallery-py313-optional, python-ver: "3.13", os: windows-latest }
+          - { name: linux-gallery-python3.10-minimum   , test-tox-env: gallery-py310-minimum , python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-gallery-python3.14-optional  , test-tox-env: gallery-py314-optional, python-ver: "3.14", os: ubuntu-latest }
+          - { name: windows-gallery-python3.10-minimum , test-tox-env: gallery-py310-minimum , python-ver: "3.10", os: windows-latest }
+          - { name: windows-gallery-python3.14-optional, test-tox-env: gallery-py314-optional, python-ver: "3.14", os: windows-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -113,9 +113,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.9-minimum  , test-tox-env: py39-minimum  , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: conda-linux-python3.13         , test-tox-env: py313         , python-ver: "3.13", os: ubuntu-latest }
-          - { name: conda-linux-python3.13-optional, test-tox-env: py313-optional, python-ver: "3.13", os: ubuntu-latest }
+          - { name: conda-linux-python3.10-minimum , test-tox-env: py310-minimum , python-ver: "3.10", os: ubuntu-latest }
+          - { name: conda-linux-python3.14         , test-tox-env: py314         , python-ver: "3.14", os: ubuntu-latest }
+          - { name: conda-linux-python3.14-optional, test-tox-env: py314-optional, python-ver: "3.14", os: ubuntu-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: '3.13'
+    python: '3.14'
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF-ZARR Changelog
 
+## Upcoming
+
+### Changed
+- Dropped testing for Python 3.9. @rly [#298](https://github.com/hdmf-dev/hdmf-zarr/pull/298)
+- Added support for Python 3.14. @rly [#298](https://github.com/hdmf-dev/hdmf-zarr/pull/298)
+
 ## 0.12.0 (October 8, 2025)
 
 ### Changed

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -31,7 +31,7 @@ often useful to use the ``dev`` branch of the ``hdmf`` GitHub repository.
 
 .. code-block::
 
-    conda create --name hdmf-zarr-dev python=3.13
+    conda create --name hdmf-zarr-dev python=3.14
     conda activate hdmf-zarr-dev
 
     git clone --recurse-submodules https://github.com/hdmf-dev/hdmf.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "hdmf>=4.1.0",
     "zarr>=2.18.0, <3.0",  # pin below 3.0 until HDMF-zarr supports zarr 3.0
     "numpy>=1.24.0",
-    "numcodecs>=0.12.0, <0.16.0",  # numcodecs 0.16.0 is not compatible with zarr<3
+    "numcodecs>=0.12.0",
     "pynwb>=2.8.3",
     "threadpoolctl>=3.1.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,15 +11,15 @@ authors = [
 ]
 description = "A package defining a Zarr I/O backend for HDMF"
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "BSD"}
 classifiers = [
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: BSD License",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,9 @@ download = True
 setenv =
   PYTHONDONTWRITEBYTECODE = 1
   macos: ARCHFLAGS = -arch arm64  # required to build numcodecs 0.15.1
+  macos: CFLAGS = -arch arm64  # required to build numcodecs 0.15.1
+  macos: LDFLAGS = -arch arm64  # required to build numcodecs 0.15.1
   macos: MACOSX_DEPLOYMENT_TARGET = 13.0  # required to build numcodecs 0.15.1
-  macos: CFLAGS = -DZSTD_DISABLE_ASM  # disable zstd build optimizatons for numcodecs 0.15.1
 install_command =
     python -m pip install -U {opts} {packages}
 extras = test

--- a/tox.ini
+++ b/tox.ini
@@ -14,10 +14,6 @@ requires = pip >= 24.3.1
 download = True
 setenv =
   PYTHONDONTWRITEBYTECODE = 1
-  macos: ARCHFLAGS = -arch arm64  # required to build numcodecs 0.15.1
-  macos: CFLAGS = -arch arm64  # required to build numcodecs 0.15.1
-  macos: LDFLAGS = -arch arm64  # required to build numcodecs 0.15.1
-  macos: MACOSX_DEPLOYMENT_TARGET = 13.0  # required to build numcodecs 0.15.1
 install_command =
     python -m pip install -U {opts} {packages}
 extras = test
@@ -37,6 +33,18 @@ commands =
 
 # Envs that run tests
 [testenv:py{310,311,312,313,314}]
+commands = {[testenv]commands}
+
+# Test with python 3.13 and all optional dependencies
+[testenv:py313-optional]
+extras = {[testenv]extras}, full
+commands = {[testenv]commands}
+
+# Test with python 3.13 and all optional dependencies, using pre-release versions
+[testenv:py313-prerelease]
+install_command =
+    python -m pip install -U --pre {opts} {packages}
+extras = {[testenv]extras}, full
 commands = {[testenv]commands}
 
 # Test with python 3.14 and all optional dependencies
@@ -87,6 +95,18 @@ commands =
     python test_gallery.py
 
 [testenv:gallery-{py310,py311,py312,py313,py314}]
+commands = {[testenv:gallery]commands}
+
+# Test with python 3.13 and all optional dependencies
+[testenv:gallery-py313-optional]
+extras = {[testenv:gallery]extras}, full
+commands = {[testenv:gallery]commands}
+
+# Test with python 3.13 and all optional dependencies, using pre-release versions
+[testenv:gallery-py313-prerelease]
+install_command =
+    python -m pip install -U --pre {opts} {packages}
+extras = {[testenv:gallery]extras}, full
 commands = {[testenv:gallery]commands}
 
 # Test with python 3.14 and all optional dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ setenv =
   PYTHONDONTWRITEBYTECODE = 1
   macos: ARCHFLAGS = -arch arm64  # required to build numcodecs 0.15.1
   macos: MACOSX_DEPLOYMENT_TARGET = 13.0  # required to build numcodecs 0.15.1
+  macos: CFLAGS = -DZSTD_DISABLE_ASM  # disable zstd build optimizatons for numcodecs 0.15.1
 install_command =
     python -m pip install -U {opts} {packages}
 extras = test

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ requires = pip >= 24.3.1
 download = True
 setenv =
   PYTHONDONTWRITEBYTECODE = 1
+  macos: ARCHFLAGS = -arch arm64  # required to build numcodecs 0.15.1
+  macos: MACOSX_DEPLOYMENT_TARGET = 13.0  # required to build numcodecs 0.15.1
 install_command =
     python -m pip install -U {opts} {packages}
 extras = test

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@
 # Tox is used by the GitHub Actions workflow to run tests on multiple environments.
 
 [tox]
-# NOTE: if the string "py39" is in the environment name, then the py39 interpreter is used,
+# NOTE: if the string "py310" is in the environment name, then the py310 interpreter is used,
 # so we can omit specifying the basepython version below.
-envlist = py39, py310, py311, py312, py313
+envlist = py310, py311, py312, py313, py314
 requires = pip >= 24.3.1
 
 [testenv]
@@ -24,7 +24,7 @@ commands =
 
 # Env to create coverage report locally
 [testenv:localcoverage]
-basepython = python3.13
+basepython = python3.14
 commands =
     python -m pip list
     python -m pip check
@@ -32,23 +32,23 @@ commands =
     coverage html -d tests/coverage/htmlcov
 
 # Envs that run tests
-[testenv:py{39,310,311,312,313}]
+[testenv:py{310,311,312,313,314}]
 commands = {[testenv]commands}
 
-# Test with python 3.13 and all optional dependencies
-[testenv:py313-optional]
+# Test with python 3.14 and all optional dependencies
+[testenv:py314-optional]
 extras = {[testenv]extras}, full
 commands = {[testenv]commands}
 
-# Test with python 3.13 and all optional dependencies, using pre-release versions
-[testenv:py313-prerelease]
+# Test with python 3.14 and all optional dependencies, using pre-release versions
+[testenv:py314-prerelease]
 install_command =
     python -m pip install -U --pre {opts} {packages}
 extras = {[testenv]extras}, full
 commands = {[testenv]commands}
 
-# Test with python 3.9 and minimum dependencies
-[testenv:py39-minimum]
+# Test with python 3.10 and minimum dependencies
+[testenv:py310-minimum]
 install_command =
     python -m pip install {opts} {packages}
 deps =
@@ -63,7 +63,7 @@ commands =
     python -m pip list
     python -m pip check
     python -m build
-    
+
 
 # Envs that will test installation from a wheel
 [testenv:wheelinstall]
@@ -82,23 +82,23 @@ commands =
     python -m pip check
     python test_gallery.py
 
-[testenv:gallery-{py39,py310,py311,py312,py313}]
+[testenv:gallery-{py310,py311,py312,py313,py314}]
 commands = {[testenv:gallery]commands}
 
-# Test with python 3.13 and all optional dependencies
-[testenv:gallery-py313-optional]
+# Test with python 3.14 and all optional dependencies
+[testenv:gallery-py314-optional]
 extras = {[testenv:gallery]extras}, full
 commands = {[testenv:gallery]commands}
 
-# Test with python 3.13 and all optional dependencies, using pre-release versions
-[testenv:gallery-py313-prerelease]
+# Test with python 3.14 and all optional dependencies, using pre-release versions
+[testenv:gallery-py314-prerelease]
 install_command =
     python -m pip install -U --pre {opts} {packages}
 extras = {[testenv:gallery]extras}, full
 commands = {[testenv:gallery]commands}
 
-# Test with python 3.9 and minimum dependencies
-[testenv:gallery-py39-minimum]
+# Test with python 3.10 and minimum dependencies
+[testenv:gallery-py310-minimum]
 install_command =
     python -m pip install {opts} {packages}
 deps =


### PR DESCRIPTION
## Motivation

Python 3.14 was released today, minimum testing with Python 3.9 has issues (#297), and Python 3.9 reaches EOL at the end of the month, so I wanted to see what breaks if we drop support for Python 3.9 and add support for Python 3.14. 

Short answer is that it's still too soon so this is a WIP. Python 3.14 is not even available on conda-forge yet.
 
## How to test the behavior?
Run all tests


## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?