### PR TITLE
Bump minimum numcodecs version for py39 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Renamed `ZarrIO.file` property to `ZarrIO._file` to be consistent with PyNWB validator. @rly [#294](https://github.com/hdmf-dev/hdmf-zarr/pull/294)
 - When loading namespaces with `ZarrIO`, all namespaces are now passed to `namespace_catalog.load_namespaces` to handle ordering of loading and detection of version conflicts, to be consistent with `HDF5IO`. @rly [#294](https://github.com/hdmf-dev/hdmf-zarr/pull/294)
 - Renamed test module `tests/unit/utils.py` to `tests/unit/helpers/utils.py`. [#292](https://github.com/hdmf-dev/hdmf-zarr/pull/292)
+- Bumped minimum required version of `numcodecs` to 0.12.0 to address installation issues with Python 3.9 on MacOS. @rly [#299](https://github.com/hdmf-dev/hdmf-zarr/pull/299)
 
 ### Added
 - Added `ZarrIO.load_namespaces_io` method to load namespaces from a given Zarr group into a given `NamespaceCatalog`. @rly [#292](https://github.com/hdmf-dev/hdmf-zarr/pull/292)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "hdmf>=4.1.0",
     "zarr>=2.18.0, <3.0",  # pin below 3.0 until HDMF-zarr supports zarr 3.0
     "numpy>=1.24.0",
-    "numcodecs>=0.11.0, <0.16.0",  # numcodecs 0.16.0 is not compatible with zarr<3
+    "numcodecs>=0.12.0, <0.16.0",  # numcodecs 0.16.0 is not compatible with zarr<3
     "pynwb>=2.8.3",
     "threadpoolctl>=3.1.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "hdmf>=4.1.0",
     "zarr>=2.18.0, <3.0",  # pin below 3.0 until HDMF-zarr supports zarr 3.0
     "numpy>=1.24.0",
-    "numcodecs>=0.10.0, <0.16.0",  # numcodecs 0.16.0 is not compatible with zarr<3
+    "numcodecs>=0.11.0, <0.16.0",  # numcodecs 0.16.0 is not compatible with zarr<3
     "pynwb>=2.8.3",
     "threadpoolctl>=3.1.0",
 ]

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,6 +3,6 @@
 hdmf==4.1.0
 zarr==2.18.0
 numpy==1.24.0
-numcodecs==0.10.0
+numcodecs==0.11.0
 pynwb==2.8.3
 threadpoolctl==3.1.0

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,6 +3,6 @@
 hdmf==4.1.0
 zarr==2.18.0
 numpy==1.24.0
-numcodecs==0.11.0
+numcodecs==0.12.0
 pynwb==2.8.3
 threadpoolctl==3.1.0


### PR DESCRIPTION
## Motivation

Fix #297.

## How to test the behavior?
Run macosx-py39-minimum workflow

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?