### PR TITLE
Prepare 0.12.0 release 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,5 @@ dmypy.json
 
 # Version
 _version.py
+
+.ruff_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: check-json
     -   id: check-toml
 -   repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.9.0
     hooks:
     -   id: black
         exclude: ^docs/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ autodoc_member_order = 'bysource'
 
 project = 'hdmf_zarr'
 copyright = '2017-2025, Oliver Ruebel'
-author = 'Oliver Ruebel, Matthew Avaylon'
+author = 'Oliver Ruebel, Matthew Avaylon, Ryan Ly, Stephanie Prince'
 
 # The short X.Y version.
 version = hdmf_zarr.__version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ full = [
 
 # development dependencies
 test = [
+    "black",
     "codespell",
     "hdf5plugin",  # hdf5plugin is used to test conversion of plugin filters
     "pre-commit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
   { name="Oliver Ruebel", email="oruebel@lbl.gov" },
   { name="Matthew Avaylon", email="mavaylon@lbl.gov" },
   { name="Ryan Ly", email="rly@lbl.gov" },
+  { name="Stephanie Prince", email="smprince@lbl.gov" },
 ]
 description = "A package defining a Zarr I/O backend for HDMF"
 readme = "README.rst"


### PR DESCRIPTION
Minor changes:
- Added Steph to authors list
- Updated black pre-commit config version
- Added black to dev dependencies
- Add `.ruff_cache` to `.gitignore`

Changelog is already set for 0.12.0 to be released Oct 8.

Prepare for release of HDMF-Zarr 0.12.0

### Before merging:
- [x] Make sure all PRs to be included in this release have been merged to `dev`.
- [x] Major and minor releases: Update dependency ranges in `pyproject.toml` and minimums in 
  `requirements-min.txt` as needed.
- [x] Check legal file dates and information in `License.txt`, `README.rst`, `docs/source/conf.py`,
  and any other locations as needed
- [x] Update `pyproject.toml` as needed
- [x] Update `README.rst` as needed
- [x] Update changelog (set release date) in `CHANGELOG.md` and any other docs as needed
- [x] Run tests locally including gallery tests, and inspect all warnings and outputs
  (`pytest && python test_gallery.py`)
- [x] Test docs locally and inspect all warnings and outputs `cd docs; make clean && make html`
- [x] After pushing this branch to GitHub, manually trigger the "Run all tests" GitHub Actions workflow on this
  branch by going to https://github.com/hdmf-dev/hdmf-zarr/actions/workflows/run_all_tests.yml, selecting
  "Run workflow" on the right, selecting this branch, and clicking "Run workflow". Make sure all tests pass.
- [x] Check that the readthedocs build for this PR succeeds (see the PR check)

### After merging:
1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release [tag]` if set up
2. After the CI bot creates the new release (wait ~10 min), update the release notes on the
   [GitHub releases page](https://github.com/hdmf-dev/hdmf-zarr/releases) with the changelog
3. Check that the readthedocs "latest" build runs and succeeds
4. Either monitor [conda-forge/hdmf_zarr-feedstock](https://github.com/conda-forge/hdmf_zarr-feedstock) for the
   regro-cf-autotick-bot bot to create a PR updating the version of HDMF to the latest PyPI release, usually within
   24 hours of release, or manually create a PR updating `recipe/meta.yaml` with the latest version number
   and SHA256 retrieved from PyPI > HDMF-Zarr > Download Files > View hashes for the `.tar.gz` file. Re-render and 
   update the dependencies as needed.
