### PR TITLE
Consolidate metadata after caching spec on export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF-ZARR Changelog
 
+## Upcoming
+
+### Fixed
+- Fixed bug where the cached spec was not included in consolidated metadata when exporting using `ZarrIO`. @rly [#315](https://github.com/hdmf-dev/hdmf-zarr/pull/315)
+
+
 ## 0.12.0 (October 8, 2025)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fixed bug where the cached spec was not included in consolidated metadata when exporting using `ZarrIO`. @rly [#315](https://github.com/hdmf-dev/hdmf-zarr/pull/315)
+- Fixed bug where consolidated metadata was always written by `ZarrIO`. @rly [#315](https://github.com/hdmf-dev/hdmf-zarr/pull/315)
 
 
 ## 0.12.0 (October 8, 2025)

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -385,14 +385,14 @@ class ZarrIO(HDMFIO):
     )
     def write(self, **kwargs):
         """Overwrite the write method to add support for caching the specification and parallelization."""
-        cache_spec, number_of_jobs, max_threads_per_process, multiprocessing_context, consolidate_metadata = popargs(
+        cache_spec, number_of_jobs, max_threads_per_process, multiprocessing_context = popargs(
             "cache_spec",
             "number_of_jobs",
             "max_threads_per_process",
             "multiprocessing_context",
-            "consolidate_metadata",
             kwargs,
         )
+        consolidate_metadata = kwargs["consolidate_metadata"]
 
         self.__dci_queue = ZarrIODataChunkIteratorQueue(
             number_of_jobs=number_of_jobs,
@@ -400,7 +400,7 @@ class ZarrIO(HDMFIO):
             multiprocessing_context=multiprocessing_context,
         )
 
-        super(ZarrIO, self).write(**kwargs)
+        super().write(**kwargs)
         if cache_spec:
             self.__cache_spec()
 
@@ -494,6 +494,7 @@ class ZarrIO(HDMFIO):
             )
 
         write_args["export_source"] = src_io.source  # pass export_source=src_io.source to write_builder
+        write_args["consolidate_metadata"] = consolidate_metadata
         ckwargs = kwargs.copy()
         ckwargs["write_args"] = write_args
         if not write_args.get("link_data", True):

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -457,6 +457,12 @@ class ZarrIO(HDMFIO):
             ),
             "default": None,
         },
+        {
+            "name": "consolidate_metadata",
+            "type": bool,
+            "doc": ("Consolidate metadata into a single .zmetadata file in the root group to accelerate read."),
+            "default": True,
+        },
     )
     def export(self, **kwargs):
         """Export data read from a file from any backend to Zarr.
@@ -472,6 +478,7 @@ class ZarrIO(HDMFIO):
         number_of_jobs, max_threads_per_process, multiprocessing_context = popargs(
             "number_of_jobs", "max_threads_per_process", "multiprocessing_context", kwargs
         )
+        consolidate_metadata = popargs("consolidate_metadata", kwargs)
 
         self.__dci_queue = ZarrIODataChunkIteratorQueue(
             number_of_jobs=number_of_jobs,
@@ -500,6 +507,10 @@ class ZarrIO(HDMFIO):
                         name=namespace, namespace=src_io.manager.namespace_catalog.get_namespace(namespace)
                     )
             self.__cache_spec()
+
+        # Reconsolidate metadata after the spec has been cached
+        if consolidate_metadata:
+            zarr.consolidate_metadata(store=self.path)
 
     def get_written(self, builder, check_on_disk=False):
         """

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -268,6 +268,26 @@ class BaseTestZarrWriter(BaseZarrWriterTestCase):
         read_types = CacheSpecTestHelper.get_types(ns_catalog)
         self.assertSetEqual(source_types, read_types)
 
+    def test_cache_spec_no_consolidation(self):
+        """Test that writing with cache_spec but without consolidate_metadata still writes .specloc."""
+        tempIO = ZarrIO(self.store_path, manager=self.manager, mode="w")
+
+        # Setup all the data we need
+        foo1 = Foo("foo1", [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
+        foo2 = Foo("foo2", [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
+        foobucket = FooBucket("test_bucket", [foo1, foo2])
+        foofile = FooFile(buckets=[foobucket])
+
+        # Write without consolidating metadata
+        tempIO.write(foofile, cache_spec=True, consolidate_metadata=False)
+        tempIO.close()
+
+        # Verify that .specloc is written (use r- mode to force read without consolidated metadata)
+        readIO = ZarrIO(self.store_path, manager=self.manager, mode="r-")
+        self.assertIn(".specloc", readIO._file.attrs.keys())
+
+        assert not os.path.exists(os.path.join(self.store_path, ".zmetadata"))
+
     def test_load_namespaces_io(self):
         tempIO = ZarrIO(self.store_path, manager=self.manager, mode="w")
 
@@ -1136,6 +1156,27 @@ class BaseTestExportZarrToZarr(BaseZarrWriterTestCase):
                 with self.assertRaisesWith(ValueError, msg):
                     export_io.export(src_io=read_io, container=dummy_file)
 
+    def test_export_no_consolidation(self):
+        """Test that exporting with consolidate_metadata=False works."""
+        foo1 = Foo("foo1", [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
+        foobucket = FooBucket("bucket1", [foo1])
+        foofile = FooFile(buckets=[foobucket])
+
+        with ZarrIO(self.store_path[0], manager=get_foo_buildmanager(), mode="w") as write_io:
+            write_io.write(foofile, consolidate_metadata=False)
+
+        with ZarrIO(self.store_path[0], manager=get_foo_buildmanager(), mode="r") as read_io:
+            read_foofile = read_io.read()
+
+            with ZarrIO(self.store_path[1], mode="w") as export_io:
+                export_io.export(src_io=read_io, container=read_foofile, consolidate_metadata=False)
+
+        with ZarrIO(self.store_path[1], manager=get_foo_buildmanager(), mode="r-") as read_io:
+            read_foofile = read_io.read()
+            self.assertContainerEqual(foofile, read_foofile, ignore_hdmf_attrs=True)
+        
+        assert not os.path.exists(os.path.join(self.store_path[1], ".zmetadata"))
+
     def test_cache_spec_disabled(self):
         """Test that exporting with cache_spec disabled works."""
         foo1 = Foo("foo1", [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
@@ -1189,6 +1230,27 @@ class BaseTestExportZarrToZarr(BaseZarrWriterTestCase):
         with ZarrIO(self.store_path[1], manager=get_foo_buildmanager(), mode="r") as read_io:
             self.assertIn(".specloc", read_io._file.attrs.keys())
 
+    def test_cache_spec_no_consolidation(self):
+        """Test that exporting with cache_spec but without consolidate_metadata still writes .specloc."""
+        foo1 = Foo("foo1", [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
+        foobucket = FooBucket("bucket1", [foo1])
+        foofile = FooFile(buckets=[foobucket])
+
+        with ZarrIO(self.store_path[0], manager=get_foo_buildmanager(), mode="w") as write_io:
+            write_io.write(foofile, consolidate_metadata=False)
+
+        with ZarrIO(self.store_path[0], manager=get_foo_buildmanager(), mode="r") as read_io:
+            read_foofile = read_io.read()
+
+            with ZarrIO(self.store_path[1], mode="w") as export_io:
+                export_io.export(src_io=read_io, container=read_foofile, cache_spec=True, consolidate_metadata=False)
+
+        # Verify that .specloc is written (use r- mode to force read without consolidated metadata)
+        with ZarrIO(self.store_path[1], manager=get_foo_buildmanager(), mode="r-") as read_io:
+            self.assertIn(".specloc", read_io._file.attrs.keys())
+
+        assert not os.path.exists(os.path.join(self.store_path[1], ".zmetadata"))
+        
     def test_soft_link_group(self):
         """
         Test that exporting a written file with soft linked groups keeps links within the file." ,i.e, we have

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -1170,6 +1170,25 @@ class BaseTestExportZarrToZarr(BaseZarrWriterTestCase):
         with zarr.open(self.store_path[1], mode="r") as zarr_io:
             self.assertTrue("specifications" in zarr_io.keys())
 
+    def test_cache_spec_consolidated(self):
+        """Test that exporting with cache_spec and consolidate_metadata writes .specloc to consolidated metadata."""
+        foo1 = Foo("foo1", [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
+        foobucket = FooBucket("bucket1", [foo1])
+        foofile = FooFile(buckets=[foobucket])
+
+        with ZarrIO(self.store_path[0], manager=get_foo_buildmanager(), mode="w") as write_io:
+            write_io.write(foofile)
+
+        with ZarrIO(self.store_path[0], manager=get_foo_buildmanager(), mode="r") as read_io:
+            read_foofile = read_io.read()
+
+            with ZarrIO(self.store_path[1], mode="w") as export_io:
+                export_io.export(src_io=read_io, container=read_foofile, cache_spec=True, consolidate_metadata=True)
+
+        # Verify that .specloc is in the consolidated metadata (readable after consolidation)
+        with ZarrIO(self.store_path[1], manager=get_foo_buildmanager(), mode="r") as read_io:
+            self.assertIn(".specloc", read_io._file.attrs.keys())
+
     def test_soft_link_group(self):
         """
         Test that exporting a written file with soft linked groups keeps links within the file." ,i.e, we have


### PR DESCRIPTION
## Motivation

- Fix #314 
- Fix #316

## How to test the behavior?
```
Export using ZarrIO. Run tests.
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?