### PR TITLE
Update macOS runners in test workflows

### DIFF
--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -106,7 +106,7 @@ jobs:
           - { name: windows-gallery-python3.10-minimum   , test-tox-env: gallery-py310-minimum   , python-ver: "3.10", os: windows-latest }
           - { name: windows-gallery-python3.14-optional  , test-tox-env: gallery-py314-optional  , python-ver: "3.14", os: windows-latest }
           - { name: windows-gallery-python3.14-prerelease, test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: windows-latest }
-          - { name: macos-gallery-python3.10-minimum     , test-tox-env: gallery-py310-minimum   , python-ver: "3.10", os: macos-13 }
+          - { name: macos-gallery-python3.10-minimum     , test-tox-env: gallery-py310-minimum   , python-ver: "3.10", os: macos-15-intel }
           - { name: macos-gallery-python3.13-optional    , test-tox-env: gallery-py313-optional  , python-ver: "3.13", os: macos-latest }
           - { name: macos-gallery-python3.13-prerelease  , test-tox-env: gallery-py313-prerelease, python-ver: "3.13", os: macos-latest }
           # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -41,7 +41,7 @@ jobs:
           - { name: windows-python3.14           , test-tox-env: py314           , python-ver: "3.14", os: windows-latest }
           - { name: windows-python3.14-optional  , test-tox-env: py314-optional  , python-ver: "3.14", os: windows-latest }
           - { name: windows-python3.14-prerelease, test-tox-env: py314-prerelease, python-ver: "3.14", os: windows-latest }
-          - { name: macos-python3.10-minimum     , test-tox-env: py310-minimum   , python-ver: "3.10", os: macos-13 }
+          - { name: macos-python3.10-minimum     , test-tox-env: py310-minimum   , python-ver: "3.10", os: macos-15-intel }
           - { name: macos-python3.10             , test-tox-env: py310           , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.11             , test-tox-env: py311           , python-ver: "3.11", os: macos-latest }
           - { name: macos-python3.12             , test-tox-env: py312           , python-ver: "3.12", os: macos-latest }

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,7 +25,7 @@ jobs:
           - { name: windows-python3.10-minimum , test-tox-env: py310-minimum , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.14         , test-tox-env: py314         , python-ver: "3.14", os: windows-latest }
           - { name: windows-python3.14-optional, test-tox-env: py314-optional, python-ver: "3.14", os: windows-latest }
-          - { name: macos-python3.10-minimum   , test-tox-env: py310-minimum , python-ver: "3.10", os: macos-13 }
+          - { name: macos-python3.10-minimum   , test-tox-env: py310-minimum , python-ver: "3.10", os: macos-15-intel }
           - { name: macos-python3.13           , test-tox-env: py313         , python-ver: "3.13", os: macos-latest }
           - { name: macos-python3.13-optional  , test-tox-env: py313-optional, python-ver: "3.13", os: macos-latest }
           # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest


### PR DESCRIPTION
## Motivation

Follow up to changes in #298 to update macOS-13 runners to macOS-15-intel


## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?