### PR TITLE
Ignore specifications group when reading root builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed zarr array `.info` property to display compression data ("No. bytes stored" and "Storage ratio") when using consolidated metadata stores by patching `ConsolidatedMetadataStore.getsize()` to query the underlying chunk store. @rly [#305](https://github.com/hdmf-dev/hdmf-zarr/pull/305)
 - Fixed bug where the cached spec was not included in consolidated metadata when exporting using `ZarrIO`. @rly [#315](https://github.com/hdmf-dev/hdmf-zarr/pull/315)
 - Fixed bug where consolidated metadata was always written by `ZarrIO`. @rly [#315](https://github.com/hdmf-dev/hdmf-zarr/pull/315)
+- Fixed bug where the `specifications` group and its contents were read during `ZarrIO.read_builder`. @rly [#322](https://github.com/hdmf-dev/hdmf-zarr/pull/322)
 
 ### Changed
 - Updated documentation about how the `zarr_dtype` attribute is used to specify a compound dtype (structured array) for a dataset. @rly [#313](https://github.com/hdmf-dev/hdmf-zarr/pull/313)

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1426,7 +1426,7 @@ class ZarrIO(HDMFIO):
                 raise ValueError("cannot determine type for empty data")
             return cls.get_type(data[0])
 
-    __reserve_attribute = ("zarr_dtype", "zarr_link")
+    __reserve_attribute = ("zarr_dtype", "zarr_link", SPEC_LOC_ATTR)
 
     def __list_fill__(self, parent, name, data, options=None):  # noqa: C901
         dtype = None

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1546,7 +1546,12 @@ class ZarrIO(HDMFIO):
 
     @docval(returns="a GroupBuilder representing the NWB Dataset", rtype="GroupBuilder")
     def read_builder(self):
-        f_builder = self.__read_group(self.__file, ROOT_NAME)
+        # ignore cached specs when reading builder
+        ignore_groups = set()
+        specloc = self.__file.attrs.get(SPEC_LOC_ATTR)
+        if specloc is not None:
+            ignore_groups.add(self.__file[specloc].name)
+        f_builder = self.__read_group(self.__file, ROOT_NAME, ignore_groups=ignore_groups)
         return f_builder
 
     def __set_built(self, zarr_obj, builder):
@@ -1602,7 +1607,9 @@ class ZarrIO(HDMFIO):
         path = os.path.join(fpath, path)
         return self.__built.get(path, None)
 
-    def __read_group(self, zarr_obj, name=None):
+    def __read_group(self, zarr_obj, name=None, ignore_groups=set()):
+        # NOTE: ignore_groups is a set of group names to skip when reading and only
+        # used when reading the root group to skip the specification group
         ret = self.__get_built(zarr_obj)
         if ret is not None:
             return ret
@@ -1624,6 +1631,8 @@ class ZarrIO(HDMFIO):
 
         # read sub groups
         for sub_name, sub_group in zarr_obj.groups():
+            if sub_group.name in ignore_groups:
+                continue
             sub_builder = self.__read_group(sub_group, sub_name)
             ret.set_group(sub_builder)
 

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -288,6 +288,30 @@ class BaseTestZarrWriter(BaseZarrWriterTestCase):
 
         assert not os.path.exists(os.path.join(self.store_path, ".zmetadata"))
 
+    def test_read_builder_excludes_specifications(self):
+        """Test that read_builder excludes the specifications group from the returned builder."""
+        tempIO = ZarrIO(self.store_path, manager=self.manager, mode="w")
+
+        # Setup all the data we need
+        foo1 = Foo("foo1", [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
+        foo2 = Foo("foo2", [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
+        foobucket = FooBucket("test_bucket", [foo1, foo2])
+        foofile = FooFile(buckets=[foobucket])
+
+        # Write with cache_spec=True to create the specifications group
+        tempIO.write(foofile, cache_spec=True)
+        tempIO.close()
+
+        # Verify that the specifications group exists in the Zarr file
+        zarr_file = zarr.open(self.store_path, mode="r")
+        self.assertIn("specifications", zarr_file.keys())
+
+        # Read the builder and verify the specifications group is excluded
+        readIO = ZarrIO(self.store_path, manager=self.manager, mode="r")
+        builder = readIO.read_builder()
+        self.assertNotIn("specifications", builder.groups)
+        readIO.close()
+
     def test_load_namespaces_io(self):
         tempIO = ZarrIO(self.store_path, manager=self.manager, mode="w")
 
@@ -1174,7 +1198,7 @@ class BaseTestExportZarrToZarr(BaseZarrWriterTestCase):
         with ZarrIO(self.store_path[1], manager=get_foo_buildmanager(), mode="r-") as read_io:
             read_foofile = read_io.read()
             self.assertContainerEqual(foofile, read_foofile, ignore_hdmf_attrs=True)
-        
+
         assert not os.path.exists(os.path.join(self.store_path[1], ".zmetadata"))
 
     def test_cache_spec_disabled(self):
@@ -1250,7 +1274,7 @@ class BaseTestExportZarrToZarr(BaseZarrWriterTestCase):
             self.assertIn(".specloc", read_io._file.attrs.keys())
 
         assert not os.path.exists(os.path.join(self.store_path[1], ".zmetadata"))
-        
+
     def test_soft_link_group(self):
         """
         Test that exporting a written file with soft linked groups keeps links within the file." ,i.e, we have


### PR DESCRIPTION
## Motivation

Fix #321 

## How to test the behavior?
```
Run tests
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?