### PR TITLE
Remove extras setting from wheelinstall testenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed bug where the cached spec was not included in consolidated metadata when exporting using `ZarrIO`. @rly [#315](https://github.com/hdmf-dev/hdmf-zarr/pull/315)
 - Fixed bug where consolidated metadata was always written by `ZarrIO`. @rly [#315](https://github.com/hdmf-dev/hdmf-zarr/pull/315)
 - Fixed bug where the `specifications` group and its contents were read during `ZarrIO.read_builder`. @rly [#322](https://github.com/hdmf-dev/hdmf-zarr/pull/322)
+- Fixed issue with `tox.ini` configuration. @rly [#326](https://github.com/hdmf-dev/hdmf-zarr/pull/326)
 
 ### Changed
 - Updated documentation about how the `zarr_dtype` attribute is used to specify a compound dtype (structured array) for a dataset. @rly [#313](https://github.com/hdmf-dev/hdmf-zarr/pull/313)

--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,7 @@ commands =
 
 # Envs that will test installation from a wheel
 [testenv:wheelinstall]
+extras =
 commands =
     python -m pip list
     python -m pip check

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,6 @@ commands =
 
 # Envs that will test installation from a wheel
 [testenv:wheelinstall]
-extras = null
 commands =
     python -m pip list
     python -m pip check


### PR DESCRIPTION
## Motivation

CI is failing due to the error:
```
wheelinstall: failed with extras not found for package hdmf_zarr: null (available: all, docs, full, test)
```

This might be due to a recent change in tox.

`extras = null` is interpreted as an extra literally named "null". The correct syntax is `extras = ` which overrides the inherited value from the `base [testenv]` section.

## How to test the behavior?
Run CI

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?