### PR TITLE
Fix is_remote() returning False for HTTPS URLs w/ consolidated metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed bug where consolidated metadata was always written by `ZarrIO`. @rly [#315](https://github.com/hdmf-dev/hdmf-zarr/pull/315)
 - Fixed bug where the `specifications` group and its contents were read during `ZarrIO.read_builder`. @rly [#322](https://github.com/hdmf-dev/hdmf-zarr/pull/322)
 - Fixed issue with `tox.ini` configuration. @rly [#326](https://github.com/hdmf-dev/hdmf-zarr/pull/326)
+- Fixed `ZarrIO.is_remote()` returning `False` for remote stores using consolidated metadata, which caused `resolve_ref` to mangle HTTPS URLs and fail with `PathNotFoundError` when reading links. @rly [#328](https://github.com/hdmf-dev/hdmf-zarr/pull/328)
 
 ### Changed
 - Updated documentation about how the `zarr_dtype` attribute is used to specify a compound dtype (structured array) for a dataset. @rly [#313](https://github.com/hdmf-dev/hdmf-zarr/pull/313)

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -265,10 +265,10 @@ class ZarrIO(HDMFIO):
         """Return True if the file is remote, False otherwise"""
         from zarr.storage import FSStore
 
-        if isinstance(self.__file.store, FSStore):
-            return True
-        else:
-            return False
+        store = self.__file.store
+        if isinstance(store, ConsolidatedMetadataStore):
+            store = store.store
+        return isinstance(store, FSStore)
 
     @classmethod
     @docval(

--- a/tests/unit/test_fsspec_streaming.py
+++ b/tests/unit/test_fsspec_streaming.py
@@ -44,6 +44,22 @@ class TestFSSpecStreaming(unittest.TestCase):
             self.assertIsInstance(read_io._file.store, zarr.storage.FSStore)
 
     @unittest.skipIf(not HAVE_FSSPEC, "fsspec not installed")
+    def test_is_remote_with_consolidated(self):
+        """Test that is_remote() returns True for remote HTTPS stores with consolidated metadata."""
+        with NWBZarrIO(self.https_s3_path, mode="r") as read_io:
+            read_io.open()
+            self.assertIsInstance(read_io._file.store, zarr.storage.ConsolidatedMetadataStore)
+            self.assertTrue(read_io.is_remote())
+
+    @unittest.skipIf(not HAVE_FSSPEC, "fsspec not installed")
+    def test_is_remote_without_consolidated(self):
+        """Test that is_remote() returns True for remote HTTPS stores without consolidated metadata."""
+        with NWBZarrIO(self.https_s3_path, mode="-r") as read_io:
+            read_io.open()
+            self.assertIsInstance(read_io._file.store, zarr.storage.FSStore)
+            self.assertTrue(read_io.is_remote())
+
+    @unittest.skipIf(not HAVE_FSSPEC, "fsspec not installed")
     def test_fsspec_streaming_via_read_nwb(self):
         """
         Test reading from s3 using the convenience function NWBZarrIO.read_nwb

--- a/tests/unit/test_zarrio.py
+++ b/tests/unit/test_zarrio.py
@@ -226,6 +226,23 @@ class TestConsolidateMetadata(ZarrStoreTestCase):
             except ValueError as e:
                 self.fail("ZarrIO.__open_file_consolidated raised an unexpected ValueError: {}".format(e))
 
+    def test_is_remote_local_with_consolidated(self):
+        """Test that is_remote() returns False for local stores with consolidated metadata."""
+        self.create_zarr(consolidate_metadata=True)
+        with ZarrIO(self.store_path, mode="r") as read_io:
+            read_io.open()
+            # Confirm the store is wrapped in ConsolidatedMetadataStore
+            self.assertIsInstance(read_io._file.store, zarr.storage.ConsolidatedMetadataStore)
+            self.assertFalse(read_io.is_remote())
+
+    def test_is_remote_local_without_consolidated(self):
+        """Test that is_remote() returns False for local stores without consolidated metadata."""
+        self.create_zarr()
+        with ZarrIO(self.store_path, mode="r-") as read_io:
+            read_io.open()
+            self.assertNotIsInstance(read_io._file.store, zarr.storage.ConsolidatedMetadataStore)
+            self.assertFalse(read_io.is_remote())
+
 
 class TestOverwriteExistingFile(ZarrStoreTestCase):
     def test_force_overwrite_when_file_exists(self):


### PR DESCRIPTION
When consolidated metadata is used, `zarr.open_consolidated()` wraps the underlying `FSStore` in a `ConsolidatedMetadataStore`. This caused `is_remote()` to return False for remote HTTPS stores, which led `resolve_ref()` to mangle URLs with `os.path.normpath`, producing `PathNotFoundError` when reading links.

Unwrap `ConsolidatedMetadataStore` before checking the store type, consistent with the pattern already used elsewhere in the codebase.

Fixes #327

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?