### PR TITLE
Improve dependencies

### DIFF
--- a/.github/workflows/HDMF_dev.yaml
+++ b/.github/workflows/HDMF_dev.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install HDMF_Zarr Requirements
         run: |
-          python -m pip install ".[test]"
+          python -m pip install --group test "."
 
       - name: Clone and Install HDMF Dev Branch
         run: |

--- a/.github/workflows/check_external_links.yml
+++ b/.github/workflows/check_external_links.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Sphinx dependencies and package
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[test,docs,full]"
+          python -m pip install --group docs ".[full]"
 
       - name: Check Sphinx external links
         run: sphinx-build -W -b linkcheck ./docs/source ./test_build

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -44,15 +44,16 @@ jobs:
       - name: Upgrade pip
         run: |
           python -m pip install --upgrade pip
+          python -m pip --version
 
       - name: Install package
         if: ${{ ! matrix.opt_req }}
         run: |
-          python -m pip install --dependency-groups test "."
+          python -m pip install --group test "."
 
       - name: Install package with optional dependencies
         if: ${{ matrix.opt_req }}
-        run: python -m pip install --dependency-groups test ".[full]"
+        run: python -m pip install --group test ".[full]"
 
       - name: Run tests and generate coverage report
         run: |

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -48,11 +48,11 @@ jobs:
       - name: Install package
         if: ${{ ! matrix.opt_req }}
         run: |
-          python -m pip install ".[test]"
+          python -m pip install --dependency-groups test "."
 
       - name: Install package with optional dependencies
         if: ${{ matrix.opt_req }}
-        run: python -m pip install ".[test,full]"
+        run: python -m pip install --dependency-groups test ".[full]"
 
       - name: Run tests and generate coverage report
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,11 @@ build:
   os: ubuntu-24.04
   tools:
     python: '3.14'
+  jobs:
+    install:
+      - pip install -U pip
+      - pip install ".[full]"
+      - pip install --group docs
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -16,8 +21,3 @@ sphinx:
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
-
-# Optionally set the version of Python and requirements required to build your docs
-python:
-  install:
-    - path: .[docs,full] # path to the package relative to the root

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,8 +12,7 @@ build:
   jobs:
     install:
       - pip install -U pip
-      - pip install ".[full]"
-      - pip install --group docs
+      - pip install --group docs ".[full]"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed issue with `tox.ini` configuration. @rly [#326](https://github.com/hdmf-dev/hdmf-zarr/pull/326)
 
 ### Changed
+- Replaced `requirements-min.txt` with `uv pip install --resolution lowest-direct` in tox and converted `test` and `docs` from optional dependencies to dependency groups (PEP 735), making the project compatible with uv. @h-mayorquin [#327](https://github.com/hdmf-dev/hdmf-zarr/pull/327)
 - Updated documentation about how the `zarr_dtype` attribute is used to specify a compound dtype (structured array) for a dataset. @rly [#313](https://github.com/hdmf-dev/hdmf-zarr/pull/313)
 - Dropped testing for Python 3.9. @rly [#298](https://github.com/hdmf-dev/hdmf-zarr/pull/298)
 - Added support for Python 3.14. @rly [#298](https://github.com/hdmf-dev/hdmf-zarr/pull/298)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ full = [
     "s3fs",
 ]
 
+# all runtime optional dependencies
+all = ["hdmf-zarr[full]"]
+
+[dependency-groups]
 # development dependencies
 test = [
     "black",
@@ -58,22 +62,19 @@ test = [
     "pytest-cov",
     "python-dateutil",  # used in some tests
     "ruff",
-    "scipy",  # used in some tests
+    "scipy>=1.7",  # used in some tests
     "tox",
 ]
 
 # documentation dependencies
 docs = [
-    "matplotlib",
-    "scipy",  # used in some docs
+    "matplotlib>=3.6",
+    "scipy>=1.7",  # used in some docs
     "sphinx>=4",  # improved support for docutils>=0.17
     "sphinx_rtd_theme>=1",  # <1 does not work with docutils>=0.17
-    "sphinx-gallery",
-    "sphinx-copybutton",
+    "sphinx-gallery>=0.16",
+    "sphinx-copybutton>=0.5",
 ]
-
-# all possible dependencies
-all = ["hdmf-zarr[full,test,docs]"]
 
 
 [project.urls]

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,8 +1,0 @@
-# minimum versions of package dependencies for installing HDMF
-# NOTE: these should match the minimum bound for dependencies in pyproject.toml
-hdmf==4.1.0
-zarr==2.18.0
-numpy==1.24.0
-numcodecs==0.12.0
-pynwb==2.8.3
-threadpoolctl==3.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ setenv =
   PYTHONDONTWRITEBYTECODE = 1
 install_command =
     python -m pip install -U {opts} {packages}
-extras = test
+dependency_groups = test
 commands =
     python -m pip list
     python -m pip check
@@ -37,34 +37,41 @@ commands = {[testenv]commands}
 
 # Test with python 3.13 and all optional dependencies
 [testenv:py313-optional]
-extras = {[testenv]extras}, full
+extras = full
+dependency_groups = {[testenv]dependency_groups}
 commands = {[testenv]commands}
 
 # Test with python 3.13 and all optional dependencies, using pre-release versions
 [testenv:py313-prerelease]
 install_command =
     python -m pip install -U --pre {opts} {packages}
-extras = {[testenv]extras}, full
+extras = full
+dependency_groups = {[testenv]dependency_groups}
 commands = {[testenv]commands}
 
 # Test with python 3.14 and all optional dependencies
 [testenv:py314-optional]
-extras = {[testenv]extras}, full
+extras = full
+dependency_groups = {[testenv]dependency_groups}
 commands = {[testenv]commands}
 
 # Test with python 3.14 and all optional dependencies, using pre-release versions
 [testenv:py314-prerelease]
 install_command =
     python -m pip install -U --pre {opts} {packages}
-extras = {[testenv]extras}, full
+extras = full
+dependency_groups = {[testenv]dependency_groups}
 commands = {[testenv]commands}
 
 # Test with python 3.10 and minimum dependencies
+# Uses uv with --resolution lowest-direct to install the lowest compatible
+# versions of direct dependencies, replacing the old requirements-min.txt approach.
 [testenv:py310-minimum]
-install_command =
-    python -m pip install {opts} {packages}
-deps =
-    -r requirements-min.txt
+skip_install = True
+dependency_groups = test
+commands_pre =
+    python -m pip install uv
+    python -m uv pip install --resolution lowest-direct -e .
 commands = {[testenv]commands}
 
 
@@ -99,32 +106,37 @@ commands = {[testenv:gallery]commands}
 
 # Test with python 3.13 and all optional dependencies
 [testenv:gallery-py313-optional]
-extras = {[testenv:gallery]extras}, full
+extras = full
+dependency_groups = docs
 commands = {[testenv:gallery]commands}
 
 # Test with python 3.13 and all optional dependencies, using pre-release versions
 [testenv:gallery-py313-prerelease]
 install_command =
     python -m pip install -U --pre {opts} {packages}
-extras = {[testenv:gallery]extras}, full
+extras = full
+dependency_groups = docs
 commands = {[testenv:gallery]commands}
 
 # Test with python 3.14 and all optional dependencies
 [testenv:gallery-py314-optional]
-extras = {[testenv:gallery]extras}, full
+extras = full
+dependency_groups = docs
 commands = {[testenv:gallery]commands}
 
 # Test with python 3.14 and all optional dependencies, using pre-release versions
 [testenv:gallery-py314-prerelease]
 install_command =
     python -m pip install -U --pre {opts} {packages}
-extras = {[testenv:gallery]extras}, full
+extras = full
+dependency_groups = docs
 commands = {[testenv:gallery]commands}
 
 # Test with python 3.10 and minimum dependencies
 [testenv:gallery-py310-minimum]
-install_command =
-    python -m pip install {opts} {packages}
-deps =
-    -r requirements-min.txt
+skip_install = True
+dependency_groups = test
+commands_pre =
+    python -m pip install uv
+    python -m uv pip install --resolution lowest-direct --group docs -e .
 commands = {[testenv:gallery]commands}


### PR DESCRIPTION
Replaces the manually-maintained `requirements-min.txt` with `uv pip install --resolution lowest-direct` in tox for minimum dependency testing, and converts `test` and `docs` from optional dependencies to dependency groups (PEP 735). This mirrors the approach adopted in hdmf ([hdmf-dev/hdmf#1408](https://github.com/hdmf-dev/hdmf/pull/1408)), eliminates the need to manually keep pinned minimum versions in sync with `pyproject.toml` lower bounds, and makes the project compatible with `uv`.

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?