### PR TITLE
Update s3 streaming tutorial with faster file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Added `ZarrIO.generate_dataset_html` method to generate rich HTML representations of Zarr arrays for display in Jupyter notebooks. @rly [#306](https://github.com/hdmf-dev/hdmf-zarr/pull/306)
-- Added S3 streaming tutorial with consolidated metadata guidance. @rly @oruebel [#308](https://github.com/hdmf-dev/hdmf-zarr/pull/308)
+- Added S3 streaming tutorial with consolidated metadata guidance. @rly @oruebel [#308, #330](https://github.com/hdmf-dev/hdmf-zarr/pull/308, https://github.com/hdmf-dev/hdmf-zarr/pull/330)
 
 ### Fixed
 - Fixed zarr array `.info` property to display compression data ("No. bytes stored" and "Storage ratio") when using consolidated metadata stores by patching `ConsolidatedMetadataStore.getsize()` to query the underlying chunk store. @rly [#305](https://github.com/hdmf-dev/hdmf-zarr/pull/305)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Added `ZarrIO.generate_dataset_html` method to generate rich HTML representations of Zarr arrays for display in Jupyter notebooks. @rly [#306](https://github.com/hdmf-dev/hdmf-zarr/pull/306)
-- Added S3 streaming tutorial with consolidated metadata guidance. @rly @oruebel [#308, #330](https://github.com/hdmf-dev/hdmf-zarr/pull/308, https://github.com/hdmf-dev/hdmf-zarr/pull/330)
+- Added S3 streaming tutorial with consolidated metadata guidance. @rly @oruebel [#308](https://github.com/hdmf-dev/hdmf-zarr/pull/308) [#330](https://github.com/hdmf-dev/hdmf-zarr/pull/330)
 
 ### Fixed
 - Fixed zarr array `.info` property to display compression data ("No. bytes stored" and "Storage ratio") when using consolidated metadata stores by patching `ConsolidatedMetadataStore.getsize()` to query the underlying chunk store. @rly [#305](https://github.com/hdmf-dev/hdmf-zarr/pull/305)

--- a/docs/gallery/plot_s3_streaming.py
+++ b/docs/gallery/plot_s3_streaming.py
@@ -39,8 +39,6 @@ Or install the dependencies separately:
 # Here we demonstrate reading from a public dataset in the DANDI Archive using
 # an HTTPS URL:
 
-import warnings
-
 from hdmf_zarr import NWBZarrIO
 
 # Public S3 URL from DANDI Archive (DANDISET 000719)
@@ -55,7 +53,7 @@ try:
         print(f"Identifier: {nwbfile.identifier}")
         print(f"Subject ID: {nwbfile.subject.subject_id if nwbfile.subject else 'N/A'}")
 except Exception as e:
-    warnings.warn(f"Note: Could not access S3 file (network access may be required): {e}")
+    print(f"Note: Could not access S3 file (network access may be required): {e}")
 
 ###############################################################################
 # .. note::
@@ -160,7 +158,7 @@ try:
     nwbfile = NWBZarrIO.read_nwb(s3_url)
     print(f"Session Start Time: {nwbfile.session_start_time}")
 except Exception as e:
-    warnings.warn(f"Note: Could not access S3 file (network access may be required): {e}")
+    print(f"Note: Could not access S3 file (network access may be required): {e}")
 
 ###############################################################################
 # .. note::

--- a/docs/gallery/plot_s3_streaming.py
+++ b/docs/gallery/plot_s3_streaming.py
@@ -39,10 +39,13 @@ Or install the dependencies separately:
 # Here we demonstrate reading from a public dataset in the DANDI Archive using
 # an HTTPS URL:
 
+import warnings
+
 from hdmf_zarr import NWBZarrIO
 
 # Public S3 URL from DANDI Archive (DANDISET 000719)
-s3_url = "https://dandiarchive.s3.amazonaws.com/zarr/7515c603-9940-4598-aa1b-8bf32dc9b10c/"
+# Path: sub-R6_ses-20200206T210000_behavior+ophys_DirectoryStore_rechunked.nwb.zarr
+s3_url = "https://dandiarchive.s3.amazonaws.com/zarr/c8c6b848-fbc6-4f58-85ff-e3f2618ee983/"
 
 # Open the file from S3
 try:
@@ -52,7 +55,7 @@ try:
         print(f"Identifier: {nwbfile.identifier}")
         print(f"Subject ID: {nwbfile.subject.subject_id if nwbfile.subject else 'N/A'}")
 except Exception as e:
-    print(f"Note: Could not access S3 file (network access may be required): {e}")
+    warnings.warn(f"Note: Could not access S3 file (network access may be required): {e}")
 
 ###############################################################################
 # .. note::
@@ -157,7 +160,7 @@ try:
     nwbfile = NWBZarrIO.read_nwb(s3_url)
     print(f"Session Start Time: {nwbfile.session_start_time}")
 except Exception as e:
-    print(f"Note: Could not access S3 file (network access may be required): {e}")
+    warnings.warn(f"Note: Could not access S3 file (network access may be required): {e}")
 
 ###############################################################################
 # .. note::


### PR DESCRIPTION
## Motivation

S3 streaming tutorial was pointing to a zarr file that took a while to load and had extensions. This updated tutorial takes about 10 seconds to run instead of 140 seconds.

Requires #328 to actually run

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?