### PR TITLE
Refactor is_remote tests to remove store type checks

### DIFF
--- a/tests/unit/test_fsspec_streaming.py
+++ b/tests/unit/test_fsspec_streaming.py
@@ -48,7 +48,6 @@ class TestFSSpecStreaming(unittest.TestCase):
         """Test that is_remote() returns True for remote HTTPS stores with consolidated metadata."""
         with NWBZarrIO(self.https_s3_path, mode="r") as read_io:
             read_io.open()
-            self.assertIsInstance(read_io._file.store, zarr.storage.ConsolidatedMetadataStore)
             self.assertTrue(read_io.is_remote())
 
     @unittest.skipIf(not HAVE_FSSPEC, "fsspec not installed")
@@ -56,7 +55,6 @@ class TestFSSpecStreaming(unittest.TestCase):
         """Test that is_remote() returns True for remote HTTPS stores without consolidated metadata."""
         with NWBZarrIO(self.https_s3_path, mode="-r") as read_io:
             read_io.open()
-            self.assertIsInstance(read_io._file.store, zarr.storage.FSStore)
             self.assertTrue(read_io.is_remote())
 
     @unittest.skipIf(not HAVE_FSSPEC, "fsspec not installed")

--- a/tests/unit/test_zarrio.py
+++ b/tests/unit/test_zarrio.py
@@ -231,8 +231,6 @@ class TestConsolidateMetadata(ZarrStoreTestCase):
         self.create_zarr(consolidate_metadata=True)
         with ZarrIO(self.store_path, mode="r") as read_io:
             read_io.open()
-            # Confirm the store is wrapped in ConsolidatedMetadataStore
-            self.assertIsInstance(read_io._file.store, zarr.storage.ConsolidatedMetadataStore)
             self.assertFalse(read_io.is_remote())
 
     def test_is_remote_local_without_consolidated(self):
@@ -240,7 +238,6 @@ class TestConsolidateMetadata(ZarrStoreTestCase):
         self.create_zarr()
         with ZarrIO(self.store_path, mode="r-") as read_io:
             read_io.open()
-            self.assertNotIsInstance(read_io._file.store, zarr.storage.ConsolidatedMetadataStore)
             self.assertFalse(read_io.is_remote())
 
 


### PR DESCRIPTION
## Motivation

Apply feedback from https://github.com/hdmf-dev/hdmf-zarr/pull/328#pullrequestreview-3879764393 which was auto-merged after approval.
