### PR TITLE
Resolve compatibility issues with HDMF 6.0

### DIFF
--- a/.github/workflows/HDMF_dev.yaml
+++ b/.github/workflows/HDMF_dev.yaml
@@ -27,7 +27,16 @@ jobs:
         run: |
           git clone https://github.com/hdmf-dev/hdmf.git --recurse-submodules
           cd hdmf
-          python -m pip install ".[test]"
+          python -m pip install --group test .
+          cd ..
+
+      - name: Clone and Install PyNWB Dev Branch
+        # PyNWB dev tracks HDMF dev's interfaces (e.g., the abstract HERDManager added in
+        # HDMF 5.1+). Released PyNWB may not yet satisfy these, so install PyNWB dev too.
+        run: |
+          git clone https://github.com/NeurodataWithoutBorders/pynwb.git --recurse-submodules
+          cd pynwb
+          python -m pip install .
           cd ..
 
       - name: Run HDMF_Zarr Tests

--- a/tests/unit/helpers/utils.py
+++ b/tests/unit/helpers/utils.py
@@ -728,6 +728,10 @@ class BuildDatasetShapeMixin(TestCase, metaclass=ABCMeta):
         )
         namespace_catalog = NamespaceCatalog()
         namespace_catalog.add_namespace(CORE_NAMESPACE, namespace)
+        # HDMF >= 5.0 requires explicit spec resolution after manual catalog construction.
+        # On older HDMF versions, inc-spec fields fall back to the def-spec at build time.
+        if hasattr(namespace_catalog, "resolve_all_specs"):
+            namespace_catalog.resolve_all_specs()
         type_map = TypeMap(namespace_catalog)
         type_map.register_container_type(CORE_NAMESPACE, "BarData", BarData)
         type_map.register_container_type(CORE_NAMESPACE, "BarDataHolder", BarDataHolder)

--- a/tests/unit/test_io_convert.py
+++ b/tests/unit/test_io_convert.py
@@ -281,7 +281,11 @@ class MixinTestZarrToHDF5:
             write_io.write(container)
 
         with ZarrIO(write_path, manager=self.get_manager(), mode="r") as read_io:
-            with HDF5IO(export_path, mode="w") as export_io:
+            # Pass the manager to the destination HDF5IO so its namespace catalog is populated
+            # before write. HDF5IO's write path now consults the manager to determine whether a
+            # builder's data type matches an entry in the `expandable` list (default includes
+            # VectorData and ElementIdentifiers); without the manager the lookup raises KeyError.
+            with HDF5IO(export_path, manager=self.get_manager(), mode="w") as export_io:
                 export_io.export(src_io=read_io, write_args={"link_data": False})
 
         read_io = HDF5IO(export_path, manager=self.get_manager(), mode="r")


### PR DESCRIPTION
## Summary

Three independent failures surfaced by the `HDMF Dev Branch Compatibility` workflow against HDMF dev (releasing as HDMF 6.0):

- **#343** — `TestDimensionLabels::test_build` lost `_ARRAY_DIMENSIONS` because the test helper builds a `NamespaceCatalog` manually and never calls `resolve_all_specs()`. HDMF's matched_spec refactor (hdmf-dev/hdmf#1451) now reads `dtype`/`shape`/`dims` from the resolved inc-spec instead of falling back to the def-spec, so an unresolved catalog produces `dimension_labels=None`. Fixed by calling `resolve_all_specs()` (guarded with `hasattr` for HDMF < 5.0).
- **#344** — `TestZarrToHDF5DynamicTableC0/C1::test_export_roundtrip` raised `KeyError: "'hdmf-common' not a namespace"`. HDMF's new default `expandable=("VectorData", "ElementIdentifiers")` (hdmf-dev/hdmf#1439) calls `is_sub_data_type` against the destination manager during `write_dataset`. The test built `HDF5IO(export_path, mode="w")` without a manager, so the lookup hit an empty `NamespaceCatalog`. Fixed by passing `manager=self.get_manager()` to the destination IO.
- **#345** — The `HDMF Dev Branch Compatibility` workflow only installed HDMF dev. Released PyNWB does not satisfy HDMF 5.1+'s abstract `HERDManager.external_resources`, so all NWB-based tests failed with `TypeError: Can't instantiate abstract class NWBFile`. Also, `pip install ".[test]"` against HDMF dev silently no-ops because HDMF moved its test deps from `[project.optional-dependencies]` to `[dependency-groups]` (PEP 735). Fixed by cloning PyNWB dev and switching HDMF's install to `pip install --group test .`.

## Test plan

- [x] `pytest tests` passes locally against editable HDMF dev + PyNWB dev (557 passed, 1080 subtests passed).
- [x] CI: `HDMF Dev Branch Compatibility` workflow passes on this PR.
- [x] CI: regular `Run tests` workflow still passes (verifies the `hasattr(resolve_all_specs)` guard for older HDMF and the manager-passed export path).

Closes #343.
Closes #344.
Closes #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)