### PR TITLE
Fix `resolve_ref` self-reference resolution over fsspec stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ _version.py
 .ruff_cache
 zarr_test*.zarr
 *.nwb.zarr
+
+# uv
+uv.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed bug where the `specifications` group and its contents were read during `ZarrIO.read_builder`. @rly [#322](https://github.com/hdmf-dev/hdmf-zarr/pull/322)
 - Fixed issue with `tox.ini` configuration. @rly [#326](https://github.com/hdmf-dev/hdmf-zarr/pull/326)
 - Fixed `ZarrIO.is_remote()` returning `False` for remote stores using consolidated metadata, which caused `resolve_ref` to mangle HTTPS URLs and fail with `PathNotFoundError` when reading links. @rly [#328](https://github.com/hdmf-dev/hdmf-zarr/pull/328)
+- Fixed `ZarrIO.resolve_ref` failing with `PathNotFoundError: nothing found at path ''` when resolving self-references (`source == "."`) over fsspec-backed stores. The function now short-circuits the `"."` case and reuses the already-open file instead of re-opening the URL as if it were an external store. Affects every non-trivial NWB Zarr file read over HTTPS, S3, GCS, or any other fsspec scheme. @h-mayorquin [#348](https://github.com/hdmf-dev/hdmf-zarr/pull/348)
 
 ### Changed
 - Replaced `requirements-min.txt` with `uv pip install --resolution lowest-direct` in tox and converted `test` and `docs` from optional dependencies to dependency groups (PEP 735), making the project compatible with uv. @h-mayorquin [#327](https://github.com/hdmf-dev/hdmf-zarr/pull/327)

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -871,6 +871,21 @@ class ZarrIO(HDMFIO):
         :return: 1) name of the target object
                  2) the target zarr object within the target file
         """
+        # Self-reference (`source == "."`): the target lives in this same store. Reuse
+        # the already-open file directly. Without this guard, the remote branch below
+        # would re-open the same URL via __open_file_consolidated, which fails over
+        # fsspec stores with PathNotFoundError on empty path keys.
+        if zarr_ref.get("source", None) == ".":
+            object_path = zarr_ref.get("path", None)
+            target_name = os.path.basename(object_path) if object_path else ROOT_NAME
+            target_zarr_obj = self.__file
+            if object_path is not None:
+                try:
+                    target_zarr_obj = target_zarr_obj[object_path]
+                except Exception:
+                    raise ValueError("Found bad link to object %s in file %s" % (object_path, self.source))
+            return target_name, target_zarr_obj
+
         # Extract the path as defined in the zarr_ref object
         if zarr_ref.get("source", None) is None:
             source_file = str(zarr_ref["path"])

--- a/tests/unit/test_fsspec_streaming.py
+++ b/tests/unit/test_fsspec_streaming.py
@@ -66,3 +66,22 @@ class TestFSSpecStreaming(unittest.TestCase):
         nwbfile = NWBZarrIO.read_nwb(self.s3_aind_path)
         self.assertEqual(nwbfile.identifier, "ecephys_625749_2022-08-03_15-15-06")
         self.assertEqual(nwbfile.institution, "AIND")
+
+    @unittest.skipIf(not HAVE_FSSPEC, "fsspec not installed")
+    def test_resolve_ref_self_reference_over_fsspec(self):
+        """Regression: `resolve_ref` must not re-open the URL for `source == "."` self-references.
+
+        Without the fix in `ZarrIO.resolve_ref`, reading any non-trivial NWB Zarr file over
+        fsspec fails with `PathNotFoundError: nothing found at path ''` because hdmf-zarr
+        writes every same-file reference as `{"source": ".", "path": ...}` and the resolver
+        previously passed the `"."` to `__open_file_consolidated`, which interpreted it as
+        an empty key in the fsspec store. The fix short-circuits the `"."` case and reuses
+        the already-open file directly. This test reads a public DANDI Zarr file end-to-end
+        and asserts the read completes; without the fix, the call raises before returning.
+        """
+        # DANDI 000719 file used in this repo's S3 streaming tutorial (PR #330).
+        url = "https://dandiarchive.s3.amazonaws.com/zarr/c8c6b848-fbc6-4f58-85ff-e3f2618ee983/"
+        nwbfile = NWBZarrIO.read_nwb(url)
+        self.assertEqual(nwbfile.identifier, "7208f856-f527-479f-973d-e6e72326a8ea")
+        self.assertIsNotNone(nwbfile.subject)
+        self.assertEqual(nwbfile.subject.subject_id, "R6")

--- a/tests/unit/test_zarrio.py
+++ b/tests/unit/test_zarrio.py
@@ -22,7 +22,7 @@ from tests.unit.helpers.utils import Baz, BazData, BazBucket, get_baz_buildmanag
 
 import zarr
 import numpy as np
-from hdmf_zarr.backend import ZarrIO
+from hdmf_zarr.backend import ZarrIO, ROOT_NAME
 from .helpers.utils import BuildDatasetShapeMixin, BarData, BarDataHolder
 from hdmf.spec import DatasetSpec
 import os
@@ -239,6 +239,40 @@ class TestConsolidateMetadata(ZarrStoreTestCase):
         with ZarrIO(self.store_path, mode="r-") as read_io:
             read_io.open()
             self.assertFalse(read_io.is_remote())
+
+
+class TestResolveRef(ZarrStoreTestCase):
+    """
+    Tests for ``ZarrIO.resolve_ref``, focusing on the ``source == "."`` self-reference
+    short-circuit that reuses the already-open file instead of re-opening the store.
+    """
+
+    def test_resolve_self_reference_to_object(self):
+        """A self-reference to an object returns that object and its name."""
+        self.create_zarr()
+        with ZarrIO(self.store_path, mode="r") as read_io:
+            read_io.open()
+            target_name, target_obj = read_io.resolve_ref({"source": ".", "path": "/dataset_1"})
+            self.assertEqual(target_name, "dataset_1")
+            self.assertEqual(target_obj.name, "/dataset_1")
+            np.testing.assert_array_equal(target_obj[:], read_io._file["/dataset_1"][:])
+
+    def test_resolve_self_reference_to_root(self):
+        """A self-reference with no path returns the root group named ROOT_NAME."""
+        self.create_zarr()
+        with ZarrIO(self.store_path, mode="r") as read_io:
+            read_io.open()
+            target_name, target_obj = read_io.resolve_ref({"source": ".", "path": None})
+            self.assertEqual(target_name, ROOT_NAME)
+            self.assertIs(target_obj, read_io._file)
+
+    def test_resolve_self_reference_bad_path(self):
+        """A self-reference to a nonexistent path raises a descriptive ValueError."""
+        self.create_zarr()
+        with ZarrIO(self.store_path, mode="r") as read_io:
+            read_io.open()
+            with self.assertRaisesRegex(ValueError, "Found bad link to object /does_not_exist"):
+                read_io.resolve_ref({"source": ".", "path": "/does_not_exist"})
 
 
 class TestOverwriteExistingFile(ZarrStoreTestCase):


### PR DESCRIPTION
`ZarrIO.resolve_ref` raises `PathNotFoundError: nothing found at path ''` when resolving any internal reference whose `source` is `"."` over an fsspec-backed store. `"."` is the convention `ZarrIO` itself emits for every same-file reference (Device, ElectrodeGroup, every `DynamicTableRegion` target, every cached spec link), so this error fires on essentially any non-trivial NWB Zarr file read over HTTPS, S3, GCS, or any other fsspec scheme. The bug is that `resolve_ref` re-opens the URL of the current store as if it were external: that works for local paths because `os.path.join(self.source, ".")` resolves correctly, but on fsspec stores `"."` collapses to an empty key lookup. The fix is a roughly ten-line short-circuit at the top of `resolve_ref`: when `source == "."`, reuse the already-open `self.__file` and skip `__open_file_consolidated` entirely. The existing external-source path below is untouched, so cross-file references keep working exactly as before.

Verified end-to-end against `https://dandiarchive.s3.amazonaws.com/zarr/c8c6b848-fbc6-4f58-85ff-e3f2618ee983/` (the DANDI 000719 file used by this repo's PR #330 S3 streaming tutorial); the read now returns the expected `NWBFile` and a new regression test in `test_fsspec_streaming.py` covers it. 

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?