### PR TITLE
Prepare for release of HDMF-Zarr 0.13.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -2,7 +2,7 @@ Prepare for release of HDMF-Zarr [version]
 
 ### Before merging:
 - [ ] Make sure all PRs to be included in this release have been merged to `dev`.
-- [ ] Major and minor releases: Update dependency ranges in `pyproject.toml` and minimums in 
+- [ ] Major and minor releases: Update dependency ranges in `pyproject.toml` and minimums in
   `requirements-min.txt` as needed.
 - [ ] Check legal file dates and information in `License.txt`, `README.rst`, `docs/source/conf.py`,
   and any other locations as needed
@@ -18,12 +18,12 @@ Prepare for release of HDMF-Zarr [version]
 - [ ] Check that the readthedocs build for this PR succeeds (see the PR check)
 
 ### After merging:
-1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release [tag]` if set up
+1. Create release by following steps in https://hdmf.readthedocs.io/en/stable/make_a_release.html or use alias `git pypi-release [tag]` if set up
 2. After the CI bot creates the new release (wait ~10 min), update the release notes on the
    [GitHub releases page](https://github.com/hdmf-dev/hdmf-zarr/releases) with the changelog
 3. Check that the readthedocs "latest" build runs and succeeds
 4. Either monitor [conda-forge/hdmf_zarr-feedstock](https://github.com/conda-forge/hdmf_zarr-feedstock) for the
    regro-cf-autotick-bot bot to create a PR updating the version of HDMF to the latest PyPI release, usually within
    24 hours of release, or manually create a PR updating `recipe/meta.yaml` with the latest version number
-   and SHA256 retrieved from PyPI > HDMF-Zarr > Download Files > View hashes for the `.tar.gz` file. Re-render and 
+   and SHA256 retrieved from PyPI > HDMF-Zarr > Download Files > View hashes for the `.tar.gz` file. Re-render and
    update the dependencies as needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF-ZARR Changelog
 
-## Upcoming
+## 0.13.0 (June 22, 2026)
 
 ### Added
 - Added `ZarrIO.generate_dataset_html` method to generate rich HTML representations of Zarr arrays for display in Jupyter notebooks. @rly [#306](https://github.com/hdmf-dev/hdmf-zarr/pull/306)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-“hdmf-zarr” Copyright (c) 2017-2025, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+“hdmf-zarr” Copyright (c) 2017-2026, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ autodoc_member_order = 'bysource'
 # -- Project information -----------------------------------------------------
 
 project = 'hdmf_zarr'
-copyright = '2017-2025, Oliver Ruebel'
+copyright = '2017-2026, Oliver Ruebel'
 author = 'Oliver Ruebel, Matthew Avaylon, Ryan Ly, Stephanie Prince'
 
 # The short X.Y version.


### PR DESCRIPTION
Prepare for release of HDMF-Zarr 0.13.0

### Before merging:
- [x] Make sure all PRs to be included in this release have been merged to `dev`.
- [x] Major and minor releases: Update dependency ranges in `pyproject.toml` and minimums in
  `requirements-min.txt` as needed. (No dependency range changes needed; `requirements-min.txt` was removed in #327.)
- [x] Check legal file dates and information in `License.txt`, `README.rst`, `docs/source/conf.py`,
  and any other locations as needed (Bumped copyright year to 2026 in `LICENSE.txt` and `docs/source/conf.py`.)
- [x] Update `pyproject.toml` as needed (No changes needed; version is managed by hatch-vcs from the git tag.)
- [x] Update `README.rst` as needed (No changes needed.)
- [x] Update changelog (set release date) in `CHANGELOG.md` and any other docs as needed
- [x] Run tests locally including gallery tests, and inspect all warnings and outputs
  (`pytest && python test_gallery.py`) (Unit tests pass: 557 passed. Gallery tests pass: 5 tests OK, run in a fresh Python 3.13 conda env with `[full]` extras and the `docs` group.)
- [x] Test docs locally and inspect all warnings and outputs `cd docs; make clean && make html` (Build succeeded with no warnings.)
- [x] After pushing this branch to GitHub, manually trigger the "Run all tests" GitHub Actions workflow on this
  branch by going to https://github.com/hdmf-dev/hdmf-zarr/actions/workflows/run_all_tests.yml, selecting
  "Run workflow" on the right, selecting this branch, and clicking "Run workflow". Make sure all tests pass.
  - https://github.com/hdmf-dev/hdmf-zarr/actions/runs/27993641363
- [x] Check that the readthedocs build for this PR succeeds (see the PR check)

### After merging:
1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release [tag]` if set up
2. After the CI bot creates the new release (wait ~10 min), update the release notes on the
   [GitHub releases page](https://github.com/hdmf-dev/hdmf-zarr/releases) with the changelog
3. Check that the readthedocs "latest" build runs and succeeds
4. Either monitor [conda-forge/hdmf_zarr-feedstock](https://github.com/conda-forge/hdmf_zarr-feedstock) for the
   regro-cf-autotick-bot bot to create a PR updating the version of HDMF to the latest PyPI release, usually within
   24 hours of release, or manually create a PR updating `recipe/meta.yaml` with the latest version number
   and SHA256 retrieved from PyPI > HDMF-Zarr > Download Files > View hashes for the `.tar.gz` file. Re-render and
   update the dependencies as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
