### PR TITLE
Fix deploy release workflow tox env to match Python 3.14

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run tox tests
         run: |
-          tox -e py313
+          tox -e py314
 
       - name: Build wheel and source distribution
         run: |


### PR DESCRIPTION
## Motivation

The `Deploy release` workflow failed on the `0.13.0` tag push ([failed run](https://github.com/hdmf-dev/hdmf-zarr/actions/runs/27994196980/job/82852817590)).

The workflow sets up Python 3.14 via `actions/setup-python`, but the "Run tox tests" step ran `tox -e py313`. tox could not find a `py313` interpreter, so the env was skipped and the step exited with code 1, before the build and PyPI upload steps. The mismatch was introduced in #298, which bumped `setup-python` from 3.13 to 3.14 without updating the tox env.

## Fix

Run `tox -e py314` to match the interpreter set up by `actions/setup-python`. `py314` is already a valid tox env (`[testenv:py{310,311,312,313,314}]`).

## After merging

Because the deploy workflow runs from the tree of the pushed tag, the `0.13.0` tag must be moved to a commit that includes this fix and re-pushed to re-trigger the release. Nothing was published to PyPI by the failed run (it failed before the upload step), so re-running is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)