### PR TITLE
Ensure generating html does not fail when a non-zarr array is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF-ZARR Changelog
 
+## Upcoming Release (TBD)
+
+### Fixed
+- Fixed bug where `ZarrIO.generate_dataset_html` would raise an error when called with a non-Zarr object. @oruebel [#355](https://github.com/hdmf-dev/hdmf-zarr/pull/355)
+
+
 ## 0.13.0 (June 22, 2026)
 
 ### Added

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -86,10 +86,13 @@ class ZarrIO(HDMFIO):
         str
             HTML representation of the dataset
         """
-        # get info from zarr array and generate html repr
-        zarr_info_dict = {k: v for k, v in dataset.info_items()}
-        repr_html = generate_array_html_repr(zarr_info_dict, dataset, "Zarr Array")
-
+        # Get info from zarr array and generate html repr
+        # Safeguard in case the function is called with a non-Zarr object
+        if hasattr(dataset, "info_items"): 
+            zarr_info_dict = {k: v for k, v in dataset.info_items()}
+            repr_html = generate_array_html_repr(zarr_info_dict, dataset, "Zarr Array")
+        else:
+            repr_html = generate_array_html_repr({}, dataset, "Array Read from ZarrIO (not a Zarr Array)")
         return repr_html
 
     @docval(

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -88,8 +88,8 @@ class ZarrIO(HDMFIO):
         """
         # Get info from zarr array and generate html repr
         # Safeguard in case the function is called with a non-Zarr object
-        if hasattr(dataset, "info_items"): 
-            zarr_info_dict = {k: v for k, v in dataset.info_items()}
+        if isinstance(dataset, Array):
+            zarr_info_dict = dict(dataset.info_items())
             repr_html = generate_array_html_repr(zarr_info_dict, dataset, "Zarr Array")
         else:
             repr_html = generate_array_html_repr({}, dataset, "Array Read from ZarrIO (not a Zarr Array)")

--- a/tests/unit/test_zarrio.py
+++ b/tests/unit/test_zarrio.py
@@ -440,7 +440,7 @@ class TestGenerateDatasetHtml(TestCase):
 
     def test_generate_dataset_html_non_zarr_object(self):
         """Test that passing a non-Zarr object returns an empty info dict in HTML"""
-        non_zarr_array = np.float(5)  # Just a float, not a Zarr array
+        non_zarr_array = np.float64(5)  # Just a float, not a Zarr array
         html = ZarrIO.generate_dataset_html(non_zarr_array)
 
         # Verify that HTML is generated and contains expected content

--- a/tests/unit/test_zarrio.py
+++ b/tests/unit/test_zarrio.py
@@ -437,3 +437,12 @@ class TestGenerateDatasetHtml(TestCase):
         self.assertIn("Zarr Array", html)
         self.assertIn("float64", html)
         self.assertIn("(10, 10)", html)
+
+    def test_generate_dataset_html_non_zarr_object(self):
+        """Test that passing a non-Zarr object returns an empty info dict in HTML"""
+        non_zarr_array = np.float(5)  # Just a float, not a Zarr array
+        html = ZarrIO.generate_dataset_html(non_zarr_array)
+
+        # Verify that HTML is generated and contains expected content
+        self.assertIsInstance(html, str)
+        self.assertIn("Array Read from ZarrIO (not a Zarr Array)", html)


### PR DESCRIPTION
Fix #354 

Updated `ZarrIO.generate_dataset_html` to safeguard against failure in case the function is called for a non-Zarr dataset

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [X]  Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?