### PR TITLE
[DIAGNOSTIC] Instrument the intermittent Python 3.14 CI hang

### DIFF
--- a/.github/workflows/diagnose_py314_hang.yml
+++ b/.github/workflows/diagnose_py314_hang.yml
@@ -12,7 +12,7 @@ on:
     inputs:
       iterations:
         description: "Times to run the unit test suite per job"
-        default: "10"
+        default: "40"
   pull_request:
     paths:
       - ".github/workflows/diagnose_py314_hang.yml"
@@ -57,12 +57,17 @@ jobs:
 
       - name: Run unit tests in a loop, dump stacks on hang
         run: |
-          n="${{ github.event.inputs.iterations || '10' }}"
+          n="${{ github.event.inputs.iterations || '40' }}"
           echo "Running the unit test suite $n time(s); a hang dumps thread stacks and fails."
+          # Skip test_fsspec_streaming.py: it hits real S3/DANDI over the network (minutes
+          # per run) and is not the deadlock (the hang also occurs on non-optional jobs,
+          # which skip it). Ignoring it lets every config run fast so we can do many more
+          # iterations per CI minute.
           for i in $(seq 1 "$n"); do
             echo "::group::iteration $i / $n"
             python -X faulthandler -m pytest tests/unit -q -p no:cacheprovider \
-              --timeout=300 --timeout-method=thread
+              --ignore=tests/unit/test_fsspec_streaming.py \
+              --timeout=180 --timeout-method=thread
             code=$?
             echo "::endgroup::"
             if [ "$code" -ne 0 ]; then

--- a/.github/workflows/diagnose_py314_hang.yml
+++ b/.github/workflows/diagnose_py314_hang.yml
@@ -1,0 +1,73 @@
+name: Diagnose py3.14 CI hang
+
+# Hunts the intermittent Python 3.14 test-suite deadlock (see the draft PR that
+# adds this file). Each job runs the unit tests repeatedly; pytest-timeout aborts
+# any test that hangs longer than 300s and dumps every thread's stack, so a caught
+# hang leaves an actionable traceback in the job log. Re-run via the "Run workflow"
+# button (workflow_dispatch) to keep rolling the dice, increasing `iterations` to
+# raise the odds of tripping the flake in a single run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "Times to run the unit test suite per job"
+        default: "10"
+  pull_request:
+    paths:
+      - ".github/workflows/diagnose_py314_hang.yml"
+      - "pyproject.toml"
+
+jobs:
+  hunt:
+    name: hunt-${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: linux-py314,            os: ubuntu-latest,  extras: "."       }
+          - { name: linux-py314-optional,   os: ubuntu-latest,  extras: ".[full]" }
+          - { name: conda-linux-py314,      os: ubuntu-latest,  extras: "."       }
+          - { name: windows-py314,          os: windows-latest, extras: "."       }
+          - { name: windows-py314-optional, os: windows-latest, extras: ".[full]" }
+    env:
+      # Belt-and-suspenders: also arm the interpreter's own fault handler.
+      PYTHONFAULTHANDLER: "1"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # tags are required to determine the version
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e "${{ matrix.extras }}" --group test
+          python -m pip list
+
+      - name: Run unit tests in a loop, dump stacks on hang
+        run: |
+          n="${{ github.event.inputs.iterations || '10' }}"
+          echo "Running the unit test suite $n time(s); a hang dumps thread stacks and fails."
+          for i in $(seq 1 "$n"); do
+            echo "::group::iteration $i / $n"
+            python -X faulthandler -m pytest tests/unit -q -p no:cacheprovider \
+              --timeout=300 --timeout-method=thread
+            code=$?
+            echo "::endgroup::"
+            if [ "$code" -ne 0 ]; then
+              echo "::error::iteration $i exited with code $code (see stack dump above if it hung)"
+              exit "$code"
+            fi
+          done
+          echo "All $n iteration(s) passed without hanging."

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,6 +9,7 @@ jobs:
   run-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45  # fail fast instead of burning the 6h default when a job hangs
     defaults:
       run:
         shell: bash
@@ -69,6 +70,7 @@ jobs:
   run-gallery-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45  # fail fast instead of burning the 6h default when a job hangs
     defaults:
       run:
         shell: bash
@@ -107,6 +109,7 @@ jobs:
   run-tests-on-conda:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45  # fail fast instead of burning the 6h default when a job hangs
     defaults:
      run:
        shell: bash -l {0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ test = [
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "pytest-timeout",  # dumps all thread stacks on a hung test (CI deadlock diagnosis)
     "python-dateutil",  # used in some tests
     "ruff",
     "scipy>=1.7",  # used in some tests
@@ -96,6 +97,16 @@ exclude = [".git_archival.txt"]
 [tool.hatch.build.targets.wheel]
 packages = ["src/hdmf_zarr"]
 
+
+[tool.pytest.ini_options]
+# Diagnostic instrumentation for the intermittent Python 3.14 CI deadlock.
+# pytest-timeout aborts any test that runs longer than `timeout` seconds and, with
+# the "thread" method, dumps the stack of every thread before killing the process,
+# so a hung CI job fails fast with an actionable traceback instead of spinning for
+# hours. The thread method works cross-platform and even when the main thread is
+# stuck in a C call (e.g. HDF5), which the signal method cannot interrupt.
+timeout = 300
+timeout_method = "thread"
 
 [tool.codespell]
 skip = "htmlcov,.git,.mypy_cache,.pytest_cache,.coverage,*.pdf,*.svg,venvs,.tox,./docs/_build/*,*.ipynb"


### PR DESCRIPTION
## Motivation

The Python 3.14 test jobs intermittently **deadlock** and, because the jobs have no `timeout-minutes`, run to GitHub's **6-hour** cap before being cancelled (e.g. run [#1372](https://github.com/hdmf-dev/hdmf-zarr/actions/runs/29768795216)).

The hang is **flaky and not tied to this or any single change**:
- Across runs it has hit *different* jobs, both optional and non-optional, on linux, windows, and conda.
- It also occurred on the `zarr-v3-migration` base branch (run #1369, July 7), where the `-optional` jobs hung while non-optional passed, the opposite of the most recent run.
- Other runs of the same branches passed cleanly.
- It does not reproduce in a local `python:3.14` container across the optional/non-optional/scipy/hdf5plugin permutations, consistent with a **timing-dependent threading / event-loop deadlock** on the multi-CPU CI runners (prime suspects: zarr 3's `sync()` background loop, or the multiprocessing in `test_parallel_write.py`).

There is currently **no visibility**: a hung job produces no stack trace, so the root cause can't be diagnosed.

## What this draft adds

- **`pytest-timeout`** (in the `test` dependency group) plus a global `[tool.pytest.ini_options]` timeout of **300s** with `timeout_method = "thread"`. On a hang this dumps **every thread's stack** and kills the process. The thread method is cross-platform and works even when the main thread is stuck in a C call (e.g. HDF5), which the signal method cannot interrupt. Verified locally: a hung test now prints `Timeout / Stack of MainThread ...` and fails fast.
- **`timeout-minutes: 45`** on the `run_tests.yml` jobs, a backstop for hangs *outside* a test (e.g. during install/tox setup), so a job fails in minutes rather than 6 hours.
- **`diagnose_py314_hang.yml`**, a dedicated workflow that runs the unit suite in a **loop** across the suspect py3.14 configs (linux / conda-linux / windows, optional and non-optional) to trip the flake within a single run. Re-run it from the Actions tab (`workflow_dispatch`) with an adjustable iteration count to keep rolling the dice; a caught hang leaves an actionable traceback in the log.

## How to use

1. Let this PR's CI run. If a normal job hangs, it will now self-terminate at the 300s per-test timeout with a thread dump instead of spinning.
2. To actively hunt it, trigger **Diagnose py3.14 CI hang** from the Actions tab (bump `iterations`, e.g. 20). Re-run until a job catches the deadlock, then read the dumped stacks to find where it's stuck.
3. Once the culprit is identified, the fix lands separately; the `timeout-minutes` and `pytest-timeout` bits are worth keeping regardless.

Draft: this is instrumentation to find the root cause, not the fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)