### PR TITLE
[DIAGNOSTIC] Instrument + hunt the py3.14 ZarrToHDF5 export deadlock

### DIFF
--- a/.github/workflows/diagnose_py314_hang.yml
+++ b/.github/workflows/diagnose_py314_hang.yml
@@ -1,0 +1,83 @@
+name: Diagnose py3.14 CI hang
+
+# Hunts the intermittent Python 3.14 test-suite deadlock (see the draft PR that adds
+# this file). The 6-hour hangs on this (zarr v3) branch all stall in the ZarrToHDF5
+# DynamicTable export-roundtrip tests, where a zarr v3 read (async `sync()` event
+# loop) is interleaved with an HDF5 write (h5py C calls) in one process.
+#
+# Each job runs a chosen scope of the suite in a loop of fresh pytest processes;
+# pytest-timeout aborts any test that hangs longer than 180s and dumps every
+# thread's stack, so a caught hang leaves an actionable traceback in the log.
+# Re-run via the "Run workflow" button (workflow_dispatch) to keep rolling the
+# dice; set `iterations` to override the per-scope default loop count.
+#
+# Scopes:
+#   focused   - only the ZarrToHDF5 tests (does the deadlock trip standalone?)
+#   ioconvert - the whole test_io_convert.py (preserves the HDF5ToZarr -> ZarrToHDF5
+#               ordering that precedes every observed hang)
+#   full      - the full unit suite minus the slow network streaming tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "Override loop count for every job (blank = per-scope default)"
+        default: ""
+  pull_request:
+    paths:
+      - ".github/workflows/diagnose_py314_hang.yml"
+      - "pyproject.toml"
+
+jobs:
+  hunt:
+    name: hunt-${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: focused-linux,     os: ubuntu-latest,  target: "tests/unit/test_io_convert.py -k ZarrToHDF5",              iters: 120 }
+          - { name: focused-windows,   os: windows-latest, target: "tests/unit/test_io_convert.py -k ZarrToHDF5",              iters: 120 }
+          - { name: ioconvert-linux,   os: ubuntu-latest,  target: "tests/unit/test_io_convert.py",                           iters: 60 }
+          - { name: ioconvert-windows, os: windows-latest, target: "tests/unit/test_io_convert.py",                           iters: 60 }
+          - { name: fullsuite-linux,   os: ubuntu-latest,  target: "tests/unit --ignore=tests/unit/test_fsspec_streaming.py", iters: 30 }
+    env:
+      # Belt-and-suspenders: also arm the interpreter's own fault handler.
+      PYTHONFAULTHANDLER: "1"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # tags are required to determine the version
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . --group test
+          python -m pip list
+
+      - name: Run scope in a loop of fresh processes, dump stacks on hang
+        run: |
+          n="${{ github.event.inputs.iterations || matrix.iters }}"
+          echo "Scope '${{ matrix.name }}': running '${{ matrix.target }}' $n time(s); a hang dumps thread stacks and fails."
+          for i in $(seq 1 "$n"); do
+            echo "::group::iteration $i / $n"
+            python -X faulthandler -m pytest ${{ matrix.target }} -q -p no:cacheprovider \
+              --timeout=180 --timeout-method=thread
+            code=$?
+            echo "::endgroup::"
+            if [ "$code" -ne 0 ]; then
+              echo "::error::iteration $i exited with code $code (see stack dump above if it hung)"
+              exit "$code"
+            fi
+          done
+          echo "All $n iteration(s) passed without hanging."

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,6 +9,7 @@ jobs:
   run-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45  # fail fast instead of burning the 6h default when a job hangs
     defaults:
       run:
         shell: bash
@@ -69,6 +70,7 @@ jobs:
   run-gallery-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45  # fail fast instead of burning the 6h default when a job hangs
     defaults:
       run:
         shell: bash
@@ -107,6 +109,7 @@ jobs:
   run-tests-on-conda:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45  # fail fast instead of burning the 6h default when a job hangs
     defaults:
      run:
        shell: bash -l {0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ test = [
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "pytest-timeout",  # dumps all thread stacks on a hung test (CI deadlock diagnosis)
     "python-dateutil",  # used in some tests
     "ruff",
     "scipy>=1.7",  # used in some tests
@@ -95,6 +96,18 @@ exclude = [".git_archival.txt"]
 [tool.hatch.build.targets.wheel]
 packages = ["src/hdmf_zarr"]
 
+
+[tool.pytest.ini_options]
+# Diagnostic instrumentation for the intermittent Python 3.14 CI deadlock, which
+# stalls in the ZarrToHDF5 DynamicTable export-roundtrip tests (zarr v3 `sync()`
+# event loop interacting with h5py). pytest-timeout aborts any test that runs
+# longer than `timeout` seconds and, with the "thread" method, dumps the stack of
+# every thread before killing the process, so a hung CI job fails fast with an
+# actionable traceback instead of spinning for hours. The thread method works
+# cross-platform and even when the main thread is stuck in a C call (e.g. HDF5),
+# which the signal method cannot interrupt.
+timeout = 300
+timeout_method = "thread"
 
 [tool.codespell]
 skip = "htmlcov,.git,.mypy_cache,.pytest_cache,.coverage,*.pdf,*.svg,venvs,.tox,./docs/_build/*,*.ipynb"


### PR DESCRIPTION
## Motivation

The Python 3.14 test jobs intermittently **deadlock** and, with no `timeout-minutes` set, burn GitHub's **6-hour** job cap before being cancelled (e.g. #349 runs, and the `zarr-v3-migration` base run #1369). There is currently no stack trace, so the root cause can't be diagnosed.

### Where it stalls

Reading the `pytest -v` output from **every** 6-hour hang on #349's branch, the freeze always lands on a **`ZarrToHDF5` DynamicTable export-roundtrip** test in `tests/unit/test_io_convert.py`:

| Run / job | OS | Hung test |
|---|---|---|
| #1371 `linux-python3.14` | Linux | `TestZarrToHDF5DynamicTableC0::test_export_roundtrip` |
| #1371 `conda-linux-python3.14` | Linux | `TestZarrToHDF5DynamicTableC0::test_export_roundtrip` |
| #1372 attempt‑1 `linux-python3.14` | Linux | `TestZarrToHDF5DynamicTableC0::test_export_roundtrip` |
| #1371 `windows-python3.14` | Windows | `TestZarrToHDF5DynamicTableC1::test_export_roundtrip` (started, no result) |

`MixinTestZarrToHDF5.roundtripExportContainer` reads a **zarr v3** source and exports it to **HDF5** in one process, so zarr v3's background event-loop thread (`zarr.core.sync.sync()`) is interleaved with h5py C calls. That is a classic intermittent-deadlock surface and it's timing-dependent, which is why it only trips on the multi-CPU CI runners.

### Why this branch (not `dev`)

`dev` pins `zarr>=2.18, <3` (zarr **v2**, fully synchronous, no `sync()` loop), so the deadlock cannot occur there. This branch is off `zarr-v3-migration` (`zarr>=3.1.3`), where the hang actually lives. (An earlier diagnostic PR off `dev`, #360, passed every hunt for exactly this reason and should be closed in favor of this one.)

## What this draft adds

- **`pytest-timeout`** (in the `test` group) + a global `[tool.pytest.ini_options]` timeout of **300s** with `timeout_method = "thread"`. On a hang this dumps **every thread's stack** and kills the process. Cross-platform, and works even when the main thread is stuck in an HDF5 C call, which the signal method cannot interrupt. Verified locally: a hung test prints `Timeout / Stack of MainThread ...` and fails fast.
- **`timeout-minutes: 45`** on the `run_tests.yml` jobs, a backstop for hangs outside a test.
- **`diagnose_py314_hang.yml`**, which loops fresh pytest processes over three scopes on the suspect py3.14 configs:
  - `focused` (`test_io_convert.py -k ZarrToHDF5`, 120x) — does the deadlock trip standalone?
  - `ioconvert` (whole `test_io_convert.py`, 60x) — preserves the `HDF5ToZarr -> ZarrToHDF5` ordering that precedes every observed hang.
  - `full` (unit suite minus the slow network streaming tests, 30x).
  Re-run from the Actions tab (`workflow_dispatch`, with an optional iteration override) to keep rolling the dice.

## How to use

1. Trigger **Diagnose py3.14 CI hang** (Actions tab) and re-run until a job catches the deadlock.
2. Read the dumped thread stacks: if they show `zarr.core.sync` / an event-loop wait interleaved with an h5py write, that confirms the `sync()`-vs-HDF5 hypothesis and points at the fix (e.g. closing the zarr source before the HDF5 write, or a zarr-python `sync()` bug to report upstream).

Draft: this is instrumentation to find the root cause, not the fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)