### PR TITLE
Resolve compound fields declared `uint` instead of writing them as float64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - Fixed bug where `ZarrIO.generate_dataset_html` would raise an error when called with a non-Zarr object. @oruebel [#355](https://github.com/hdmf-dev/hdmf-zarr/pull/355)
-- Fixed bug where a compound dtype field declared with the spec type `uint` (or `short`) was written as `float64`, because `ZarrIO.__dtypes` was missing those keys and the resulting `None` was passed to `np.dtype`. This affected the `HERD` index fields, among others. @ehennestad [#PRNUM](https://github.com/hdmf-dev/hdmf-zarr/pull/PRNUM)
+- Fixed bug where a compound dtype field declared with the spec type `uint` (or `short`) was written as `float64`, because `ZarrIO.__dtypes` was missing those keys and the resulting `None` was passed to `np.dtype`. This affected the `HERD` index fields, among others. @ehennestad [#365](https://github.com/hdmf-dev/hdmf-zarr/pull/365)
 
 
 ## 0.13.0 (June 22, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fixed bug where `ZarrIO.generate_dataset_html` would raise an error when called with a non-Zarr object. @oruebel [#355](https://github.com/hdmf-dev/hdmf-zarr/pull/355)
+- Fixed bug where a compound dtype field declared with the spec type `uint` (or `short`) was written as `float64`, because `ZarrIO.__dtypes` was missing those keys and the resulting `None` was passed to `np.dtype`. This affected the `HERD` index fields, among others. @ehennestad [#PRNUM](https://github.com/hdmf-dev/hdmf-zarr/pull/PRNUM)
 
 
 ## 0.13.0 (June 22, 2026)

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -1369,8 +1369,10 @@ class ZarrIO(HDMFIO):
         "uint64": np.uint64,
         "int": np.int32,
         "int32": np.int32,
+        "short": np.int16,
         "int16": np.int16,
         "int8": np.int8,
+        "uint": np.uint32,
         "bool": np.bool_,
         "bool_": np.bool_,
         "text": str,
@@ -1427,7 +1429,19 @@ class ZarrIO(HDMFIO):
         elif isinstance(dtype, dict):
             return cls.__dtypes.get(dtype["reftype"])
         elif isinstance(dtype, list):
-            return np.dtype([(x["name"], cls.__resolve_dtype_helper__(x["dtype"])) for x in dtype])
+            # A field dtype that does not resolve must not be passed on to np.dtype, which reads
+            # None as "unspecified" and silently substitutes float64. Unlike the scalar case,
+            # __resolve_dtype__ cannot fall back to inferring the dtype from the data here,
+            # because the None is consumed while the compound dtype is being built.
+            fields = []
+            for field in dtype:
+                field_dtype = cls.__resolve_dtype_helper__(field["dtype"])
+                if field_dtype is None:
+                    raise ValueError(
+                        f"Can't resolve dtype {field['dtype']!r} for compound field {field['name']!r}"
+                    )
+                fields.append((field["name"], field_dtype))
+            return np.dtype(fields)
         else:
             raise ValueError(f"Can't resolve dtype {dtype}")
 

--- a/tests/unit/test_zarrio.py
+++ b/tests/unit/test_zarrio.py
@@ -25,6 +25,8 @@ import numpy as np
 from hdmf_zarr.backend import ZarrIO, ROOT_NAME
 from .helpers.utils import BuildDatasetShapeMixin, BarData, BarDataHolder
 from hdmf.spec import DatasetSpec
+from hdmf.build import GroupBuilder, DatasetBuilder
+from hdmf.backends.hdf5.h5tools import HDF5IO
 import os
 import shutil
 import warnings
@@ -446,3 +448,58 @@ class TestGenerateDatasetHtml(TestCase):
         # Verify that HTML is generated and contains expected content
         self.assertIsInstance(html, str)
         self.assertIn("Array Read from ZarrIO (not a Zarr Array)", html)
+
+
+class TestResolveCompoundDtype(ZarrStoreTestCase):
+    """
+    Tests for resolving spec dtypes, in particular the fields of a compound dtype.
+
+    A field dtype that the lookup table does not know resolves to None, which numpy reads
+    as "unspecified" and turns into float64. Unlike a plain dataset, a compound dtype
+    cannot fall back to inferring the type from the data, because the None is consumed
+    while the compound dtype is being built.
+    """
+
+    def test_resolve_integer_aliases(self):
+        """The spec aliases 'uint' and 'short' resolve to the same types HDF5IO uses."""
+        self.assertIs(ZarrIO.__resolve_dtype_helper__("uint"), np.uint32)
+        self.assertIs(ZarrIO.__resolve_dtype_helper__("short"), np.int16)
+
+    def test_resolve_compound_dtype_keeps_unsigned_field(self):
+        """A compound field declared 'uint' resolves to uint32 rather than float64."""
+        spec = [{"name": "idx", "dtype": "uint"}, {"name": "name", "dtype": "text"}]
+        resolved = ZarrIO.__resolve_dtype_helper__(spec)
+        self.assertEqual(resolved["idx"], np.dtype(np.uint32))
+
+    def test_resolve_compound_dtype_matches_hdf5(self):
+        """The integer fields of a compound dtype resolve the same way on both backends."""
+        spec = [{"name": "idx", "dtype": "uint"}, {"name": "count", "dtype": "short"}]
+        zarr_dtype = ZarrIO.__resolve_dtype_helper__(spec)
+        hdf5_dtype = HDF5IO.__resolve_dtype_helper__(spec)
+        for field in ("idx", "count"):
+            self.assertEqual(zarr_dtype[field], hdf5_dtype[field])
+
+    def test_resolve_unknown_compound_field_raises(self):
+        """An unresolvable field dtype raises instead of silently becoming float64."""
+        spec = [{"name": "idx", "dtype": "not_a_dtype"}]
+        with self.assertRaisesWith(ValueError, "Can't resolve dtype 'not_a_dtype' for compound field 'idx'"):
+            ZarrIO.__resolve_dtype_helper__(spec)
+
+    def test_resolve_unknown_scalar_dtype_still_falls_back(self):
+        """A plain dataset still infers its dtype from the data when the spec is unknown."""
+        data = np.array([1, 2, 3], dtype=np.uint32)
+        self.assertIs(ZarrIO.__resolve_dtype__("not_a_dtype", data), np.uint32)
+
+    def test_write_compound_dtype_preserves_unsigned_field(self):
+        """An unsigned field of a written compound dataset keeps its type on disk."""
+        spec = [{"name": "idx", "dtype": "uint"}, {"name": "value", "dtype": "float"}]
+        builder = GroupBuilder(
+            ROOT_NAME,
+            datasets={"tbl": DatasetBuilder("tbl", [(0, 1.5), (1, 2.5)], dtype=spec)},
+        )
+        with ZarrIO(self.store_path, mode="w") as io:
+            io.write_builder(builder)
+
+        written = zarr.open(os.path.join(self.store_path, "tbl"), mode="r")
+        self.assertEqual(written.dtype["idx"], np.dtype(np.uint32))
+        self.assertEqual(written["idx"].tolist(), [0, 1])


### PR DESCRIPTION
Fixes #364.

## The bug

`ZarrIO.__dtypes` has no entry for the bare spec type `uint`. The lookup uses `dict.get`, so an
unknown spec type resolves to `None` rather than raising.

For a plain dataset that is harmless, because `__resolve_dtype__` recovers:

```python
@classmethod
def __resolve_dtype__(cls, dtype, data):
    dtype = cls.__resolve_dtype_helper__(dtype)
    if dtype is None:
        dtype = cls.get_type(data)      # <- infers from the data
    return dtype
```

But a compound dtype is built inside `__resolve_dtype_helper__` itself, so the `None` reaches
`np.dtype` before the fallback can see it, and numpy reads it as "unspecified":

```python
>>> np.dtype([('files_idx', None)])
dtype([('files_idx', '<f8')])
```

Every compound field declared `dtype: uint` was therefore written as `float64`. In
hdmf-common-schema that is all five HERD index fields (`objects.files_idx`,
`object_keys.{objects_idx,keys_idx}`, `entity_keys.{entities_idx,keys_idx}`), so a HERD read back
from Zarr has float indices and the row lookup rejects them:

```
TypeError: incorrect type for 'files_idx' (got 'float64', expected 'int or integer')
```

Write and read both succeed, and `HERD.to_dataframe()` works, so this can go unnoticed until
something calls `get_object_entities` or anything else routed through `_find_object`.

## The change

- Add the missing `uint` -> `np.uint32` key, matching `HDF5IO`. `short` -> `np.int16` was missing
  for the same reason and is added alongside it; those were the only two spec aliases present in
  `HDF5IO.__dtypes` and absent here that map cleanly onto Zarr. (`datetime` is also absent, but
  `HDF5IO` maps it to `object`, which means something different in this table, so I left it alone.)
- Raise on a compound field dtype that cannot be resolved, instead of passing `None` to `np.dtype`.
  Without this, the next missing key would again produce silently corrupted data rather than an
  error. The scalar fallback is deliberately untouched and is covered by a test.

Both are small enough to split if you would rather take only the table entry.

## Verification

Before and after, writing a compound dataset whose spec declares `{"name": "idx", "dtype": "uint"}`:

```
before -> [('idx', '<f8'), ('value', '<f4')]
after  -> [('idx', '<u4'), ('value', '<f4')]
```

Six tests are added in `TestResolveCompoundDtype`. Five of them fail on `dev` without the change;
the sixth guards the scalar fallback and passes either way, which is the point of it.

The full unit suite passes on this branch (551 passed, 13 skipped).

## Scope

This fixes dtype **resolution** on `dev`, which is where the bug originates, but it does not by
itself fix the HERD round-trip here: on zarr-python 2 a compound dtype containing strings goes
through the object-codec path, so `objects` comes back as `object` dtype and fails for a separate
reason. On the `zarr-v3-migration` branch (#325), where the resolved compound dtype is honoured,
this change fixes the HERD round-trip end to end — I verified that `get_object_entities` returns
the annotation correctly with the patch applied there.

I based the PR on `dev` since that is where the missing key lives; it should carry over to #325
unchanged. Happy to retarget if you would rather it land there first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
