### PR TITLE
Rebuild a resolved compound row as a record instead of a list

### DIFF
--- a/src/hdmf_zarr/zarr_utils.py
+++ b/src/hdmf_zarr/zarr_utils.py
@@ -180,6 +180,16 @@ class AbstractZarrTableDataset(DatasetOfReferences):
                 tmp.append(sub.type.__name__)
         self.__dtype = tmp
 
+        # The dtype a resolved row has in memory. Zarr v3 stores a reference inside a compound as a
+        # fixed-width string, which cannot hold the resolved Container or Builder, so the reference
+        # fields are widened to object here. This is also the dtype the HDF5 backend hands back.
+        self.__resolved_dtype = np.dtype(
+            [
+                (name, object if types[index] == DatasetBuilder.OBJECT_REF_TYPE else self.dataset.dtype[index])
+                for index, name in enumerate(self.dataset.dtype.names)
+            ]
+        )
+
     @property
     def types(self):
         return self.__types
@@ -191,18 +201,21 @@ class AbstractZarrTableDataset(DatasetOfReferences):
     def __getitem__(self, arg):
         rows = copy(super().__getitem__(arg))
         if np.issubdtype(type(arg), np.integer):
-            # In zarr v3, structured array elements are 0-d numpy void with typed fields.
-            # Convert to list so we can replace fields with resolved references (Python objects).
-            row_list = list(rows.item()) if hasattr(rows, 'item') and rows.ndim == 0 else list(rows)
-            self.__swap_refs(row_list)
-            return row_list
-        else:
-            result = []
-            for row in rows:
-                row_list = list(row.item()) if hasattr(row, 'item') and row.ndim == 0 else list(row)
-                self.__swap_refs(row_list)
-                result.append(row_list)
-            return result
+            resolved = np.empty((), dtype=self.__resolved_dtype)
+            resolved[()] = tuple(self.__resolve_row(rows))
+            return resolved[()]
+
+        rows = np.asarray(rows)
+        resolved = np.empty(rows.shape, dtype=self.__resolved_dtype)
+        for index, row in enumerate(rows):
+            resolved[index] = tuple(self.__resolve_row(row))
+        return resolved
+
+    def __resolve_row(self, row):
+        # In zarr v3 a structured array element is a 0-d numpy void, so unpack it before swapping.
+        row_list = list(row.item()) if hasattr(row, "item") and getattr(row, "ndim", None) == 0 else list(row)
+        self.__swap_refs(row_list)
+        return row_list
 
     def __swap_refs(self, row):
         for i in self.__refgetters:

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -537,6 +537,31 @@ class BaseTestZarrWriter(BaseZarrWriterTestCase):
             self.assertEqual(v[1], builder["data"][i][1])  # Compare string value from compound tuple
             self.assertTrue(np.all(v[2]["data"][:] == builder["data"][i][2]["builder"]["data"][:]))
 
+    def test_read_reference_compound_resolves_to_a_record(self):
+        """The resolved rows must come back as a structured array, not a list of lists.
+
+        test_read_reference_compound above compares rows by position, which a list also satisfies,
+        so it cannot see a regression here.
+        """
+        self.test_write_reference_compound()
+        self.read()
+        builder = self.createReferenceCompoundBuilder()["ref_dataset"]
+        read_builder = self.root["ref_dataset"]
+
+        rows = read_builder["data"][:]
+        self.assertIsInstance(rows, np.ndarray)
+        self.assertTupleEqual(rows.dtype.names, ("id", "name", "reference"))
+        self.assertIsInstance(read_builder["data"][0], np.void)
+
+        # Field access is what breaks when the rows come back as lists
+        np.testing.assert_array_equal(rows["id"], [entry[0] for entry in builder["data"]])
+        np.testing.assert_array_equal(rows["name"], [entry[1] for entry in builder["data"]])
+
+        # The reference field holds the resolved builder rather than the JSON string on disk
+        self.assertEqual(rows.dtype["reference"], np.dtype(object))
+        for i, reference in enumerate(rows["reference"]):
+            self.assertTrue(np.all(reference["data"][:] == builder["data"][i][2]["builder"]["data"][:]))
+
     def test_read_reference_compound_buf(self):
         data_1 = np.arange(100, 200, 10).reshape(2, 5)
         data_2 = np.arange(0, 200, 10).reshape(4, 5)


### PR DESCRIPTION
This has #325 as a base.

This comes from me running @oruebel's branch (#366) on the neuroconv testing suite locally. There it fails for `IntracellularRecordingsTable`. The reason is that the cell of both response and stimulus, which is the entry of a compound data type with shape `[('idx_start', '<i4'), ('count', '<i4'), ('timeseries', '<U512')]`, is never converted into such and instead kept as a list.

This makes this fail with `column.data[:]["idx_start"]`:

```
TypeError: list indices must be integers or slices, not str
```

This used to work in place. On `dev` the reference field is `|O` on disk, so `__swap_refs` could assign the resolved `TimeSeries` straight into the record. In v3 that field is `<U512`, a string field which does not work directly so I think it defaulted to wrapping the row in a list to make the assignment legal. What is missing is the conversion back from string to the object. This PR builds a resolved dtype, the same as the on-disk one but with `object` in the reference fields, once at read time, so the rows are already the right size and the resulting array is compound dtype already. This is consistent with what the HDF5 backend returns.

so we get:
```
base branch   d[0]: list   is np.void: False   d[:]: list      dtype.names: None
with this PR  d[0]: void   is np.void: True    d[:]: ndarray   dtype.names: ('idx_start', 'count', 'timeseries')
HDF5 twin     d[0]: void   is np.void: True    d[:]: ndarray   dtype.names: ('idx_start', 'count', 'timeseries')
```

The test passes unmodified on `dev`, so this is a regression rather than a new guarantee: `dev` returns a structured array here and the migration silently started returning lists.

This does not require @oruebel's PR and is a simple fix so I opened with #325 as base. I added a test so we don't fail on this again.