### PR TITLE
Decode a zarr v2 compound that holds an object field

### DIFF
--- a/src/hdmf_zarr/backend_zarrv2.py
+++ b/src/hdmf_zarr/backend_zarrv2.py
@@ -500,6 +500,11 @@ class ZarrV2IO(ZarrIO):
         is_object = dtype == np.dtype("|O") or has_object_field
         result_dtype = dtype if has_object_field else (object if is_object else dtype)
         fill_value = zarray_meta.get("fill_value", None if is_object else 0)
+        if has_object_field and isinstance(fill_value, str):
+            # A structured fill for an object-codec array is stored as base64 of a pickled scalar.
+            # Reading it back would need the pickle codec this backend gates, and zarr v2 resolves
+            # the one hdmf-zarr writes to 0, which for a record means every field zeroed.
+            fill_value = 0
         ndim = len(shape)
         chunk_grid = tuple((s + c - 1) // c for s, c in zip(shape, chunks))
 

--- a/src/hdmf_zarr/backend_zarrv2.py
+++ b/src/hdmf_zarr/backend_zarrv2.py
@@ -41,6 +41,17 @@ def _v2_codec(codec_config, allow_pickle):
     return numcodecs.get_codec(codec_config)
 
 
+def _v2_dtype(dtype_spec):
+    """Build the numpy dtype a v2 `.zarray` declares.
+
+    A compound dtype comes out of JSON as a list of lists, and `np.dtype` only accepts tuples for
+    structured fields, so the fields are converted before handing them over.
+    """
+    if isinstance(dtype_spec, list):
+        return np.dtype([tuple(field) for field in dtype_spec])
+    return np.dtype(dtype_spec)
+
+
 def _read_store_bytes(store, key):
     """Read raw bytes for *key* from a Zarr store, returning ``None`` if absent.
 
@@ -473,7 +484,7 @@ class ZarrV2IO(ZarrIO):
         """
         shape = tuple(zarray_meta["shape"])
         chunks = tuple(zarray_meta["chunks"])
-        dtype = np.dtype(zarray_meta.get("dtype", "f8"))
+        dtype = _v2_dtype(zarray_meta.get("dtype", "f8"))
         order = zarray_meta.get("order", "C")
         dimension_separator = zarray_meta.get("dimension_separator", ".")
 
@@ -483,8 +494,11 @@ class ZarrV2IO(ZarrIO):
         filters_config = zarray_meta.get("filters") or []
         filters = [_v2_codec(filter_config, allow_pickle) for filter_config in filters_config]
 
-        is_object = dtype == np.dtype("|O")
-        result_dtype = object if is_object else dtype
+        # A compound holding an object field is pickled whole, exactly like a plain object array,
+        # so it comes back from the codec as an ndarray instead of a buffer to reinterpret.
+        has_object_field = dtype.names is not None and any(dtype[name].kind == "O" for name in dtype.names)
+        is_object = dtype == np.dtype("|O") or has_object_field
+        result_dtype = dtype if has_object_field else (object if is_object else dtype)
         fill_value = zarray_meta.get("fill_value", None if is_object else 0)
         ndim = len(shape)
         chunk_grid = tuple((s + c - 1) // c for s, c in zip(shape, chunks))

--- a/tests/unit/test_zarrv2_backward_compat.py
+++ b/tests/unit/test_zarrv2_backward_compat.py
@@ -115,6 +115,61 @@ class TestV2ObjectChunkDecoding(unittest.TestCase):
         self.assertEqual(result.dtype, np.dtype(object))
         np.testing.assert_array_equal(result, expected)
 
+    def test_compound_dtype_with_an_object_field(self):
+        """A compound holding an object field is pickled whole, like a plain object array.
+
+        hdmf-zarr wrote every reference column this way before v3. The dtype comes out of the
+        ``.zarray`` JSON as a list of lists, which ``np.dtype`` only takes as tuples, the chunk comes
+        back from the codec as an ndarray rather than a buffer to reinterpret, and the fill for the
+        missing chunk is stored as base64 of a pickled scalar.
+        """
+        from numcodecs import Pickle
+
+        from hdmf_zarr.utils import ZarrReference
+
+        dtype = [("idx_start", "<i4"), ("count", "<i4"), ("timeseries", "O")]
+        metadata = {
+            "shape": [6],
+            "chunks": [2],
+            "dtype": [["idx_start", "<i4"], ["count", "<i4"], ["timeseries", "|O"]],
+            "compressor": None,
+            "filters": [{"id": "pickle", "protocol": 5}],
+            "fill_value": "gAVLAC4=",  # base64 of a pickled 0, which is what zarr v2 writes here
+            "order": "C",
+            "dimension_separator": ".",
+        }
+        codec = Pickle(protocol=5)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            array_path = os.path.join(tmpdir, "array")
+            os.makedirs(array_path)
+            with open(os.path.join(array_path, ".zarray"), "w") as f:
+                json.dump(metadata, f)
+            # Two chunks written and the third left missing, so the fill value is used.
+            for chunk_index in (0, 1):
+                values = np.array(
+                    [
+                        (index, index * 2, ZarrReference(source=".", path=f"/acquisition/s{index}"))
+                        for index in (2 * chunk_index, 2 * chunk_index + 1)
+                    ],
+                    dtype=dtype,
+                )
+                with open(os.path.join(array_path, str(chunk_index)), "wb") as f:
+                    f.write(codec.encode(values))
+
+            result = ZarrV2IO._decode_v2_dataset(
+                store=LocalStore(tmpdir),
+                dataset_key="array",
+                zarray_meta=metadata,
+                allow_pickle=True,
+            )
+
+        self.assertTupleEqual(result.dtype.names, ("idx_start", "count", "timeseries"))
+        np.testing.assert_array_equal(result["idx_start"][:4], [0, 1, 2, 3])
+        self.assertEqual(result["timeseries"][3]["path"], "/acquisition/s3")
+        self.assertEqual(tuple(result[4]), (0, 0, 0))
+        self.assertEqual(tuple(result[5]), (0, 0, 0))
+
     def test_missing_object_chunk_uses_declared_fill_value(self):
         """Missing object chunks are initialized from v2 ``fill_value`` metadata."""
         from numcodecs import VLenUTF8


### PR DESCRIPTION
I found this running this branch against the neuroconv test suite. The icephys files I wrote with the released stack, hdmf-zarr 0.13.0 on zarr 2, cannot be opened at all. The `stimulus` and `response` columns of `IntracellularRecordingsTable` are compound with an object field, `[['idx_start', '<i4'], ['count', '<i4'], ['timeseries', '|O']]`, so zarr v3 refuses them and `_decode_v2_dataset` takes over. There the dtype arrives from JSON as a list of lists where `np.dtype` wants tuples, and `is_object` matches only an exact `|O` instead of a dtype that contains an object field. `_iter_children` downgrades both to a warning and drops the column, so the failure surfaces much later as a `ConstructError` about `colnames`. This PR builds the dtype from tuples, treats "has an object field" as object, and resolves the structured `fill_value` that v2 stores as base64 of a pickled scalar to a zeroed record, the way zarr v2 itself does.

I am sending this without a test because I would like to know how you want it covered:

* Add an intracellular recording to the v2 fixture in `tests/unit/helpers`, as it has no compound dataset in it at all. That covers this end to end, but regenerating rewrites every `object_id` and the cached schema with it, so the diff is 171 files no matter what I pin in the generation venv.
* Build a synthetic v2 store in the test the way `TestV2ObjectChunkDecoding` already does. That stays small but only covers the decoder.

To be honest, my preference is the second one. The v2 path is only there for files people already have, so the decoder is what I want guarded, and I don't think there are enough v2 files around to justify 171 files of fixture churn every time we cover one more shape. But this is a one-off thing (only one v2 to v3 migration) and I am fine with whatever you guys want to move forward with.
