### PR TITLE
Align `ZarrDataIO` with the new zarr version 3 codec API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added read-only `ZarrV2IO` and `NWBZarrV2IO` backends for reading legacy Zarr v2 files, with `NWBZarrV2IO.export_to_v3` and the one-shot `NWBZarrV2IO.convert_to_v3` static helper to convert NWB Zarr v2 files to Zarr v3. @alejoe91 [#349](https://github.com/hdmf-dev/hdmf-zarr/pull/349)
 - Added a clear error when reading a Zarr v2 file with the Zarr v3 `ZarrIO`/`NWBZarrIO` that directs the user to `ZarrV2IO`/`NWBZarrV2IO`, replacing an opaque zarr-python parse error. @alejoe91 [#349](https://github.com/hdmf-dev/hdmf-zarr/pull/349)
 
+### Changed
+- Aligned `ZarrDataIO` with the zarr v3 codec API: `compressor` is renamed to `compressors`, the `serializer` (`ArrayBytesCodec`) slot is now reachable, and `filters` keeps its name for `ArrayArrayCodec` only. @h-mayorquin [#369](https://github.com/hdmf-dev/hdmf-zarr/pull/369)
+
 ### Fixed
 - Fixed bug where `ZarrIO.generate_dataset_html` would raise an error when called with a non-Zarr object. @oruebel [#355](https://github.com/hdmf-dev/hdmf-zarr/pull/355)
 - Fixed `ZarrIO._copy_array` failing to export arrays compressed with Zarr v2 numcodecs (e.g. `numcodecs.Blosc`) by mapping them to their `numcodecs.zarr3` equivalents, preserving compression/filters when exporting from Zarr v2 to v3. @alejoe91 [#349](https://github.com/hdmf-dev/hdmf-zarr/pull/349)

--- a/docs/gallery/plot_zarr_dataset_io.py
+++ b/docs/gallery/plot_zarr_dataset_io.py
@@ -47,7 +47,7 @@ data_with_data_io = ZarrDataIO(
     data=data * 3,
     chunks=(10, 10),
     fillvalue=0,
-    compressor=BloscCodec(cname='zstd', clevel=1, shuffle='shuffle')
+    compressors=BloscCodec(cname='zstd', clevel=1, shuffle='shuffle')
 )
 
 ###############################################################################
@@ -62,7 +62,7 @@ test_table.add_column(
 # Next we add a column where we explicitly disable compression
 data_without_compression = ZarrDataIO(
     data=data*5,
-    compressor=False)
+    compressors=False)
 test_table.add_column(
     name='test_data_nocompression',
     description='Some 2D test data',

--- a/src/hdmf_zarr/utils.py
+++ b/src/hdmf_zarr/utils.py
@@ -17,7 +17,7 @@ from warnings import warn
 import zarr
 import numpy as np
 from zarr import Group
-from zarr.abc.codec import BytesBytesCodec, ArrayArrayCodec
+from zarr.abc.codec import BytesBytesCodec, ArrayArrayCodec, ArrayBytesCodec
 
 from hdmf.data_utils import DataIO, GenericDataChunkIterator, DataChunkIterator, AbstractDataChunkIterator
 from hdmf.query import HDMFDataset
@@ -440,10 +440,10 @@ class ZarrDataIO(DataIO):
             "default": None,
         },
         {
-            "name": "compressor",
-            "type": (BytesBytesCodec, list, bool),
+            "name": "compressors",
+            "type": (BytesBytesCodec, list, tuple, bool),
             "doc": (
-                "Zarr compressor codec (BytesBytesCodec) to be used. Can be a single codec or list of codecs. "
+                "Zarr compressor codecs (BytesBytesCodec) to be used. Can be a single codec or list of codecs. "
                 "Set to True to use Zarr default. Set to False to disable compression. "
                 "Use zarr.codecs (e.g., zarr.codecs.BloscCodec()) or zarr.codecs.numcodecs wrappers."
             ),
@@ -453,8 +453,17 @@ class ZarrDataIO(DataIO):
             "name": "filters",
             "type": (list, tuple),
             "doc": (
-                "One or more Zarr-supported codecs (ArrayArrayCodec) used to transform data prior to compression. "
-                "Use zarr.codecs or zarr.codecs.numcodecs wrappers."
+                "One or more Zarr-supported codecs (ArrayArrayCodec) used to transform the array before it is "
+                "serialized to bytes. Use zarr.codecs or zarr.codecs.numcodecs wrappers."
+            ),
+            "default": None,
+        },
+        {
+            "name": "serializer",
+            "type": ArrayBytesCodec,
+            "doc": (
+                "Zarr codec (ArrayBytesCodec) used to serialize the array to bytes, e.g., zarr.codecs.BytesCodec(). "
+                "Zarr chooses a default for the dtype when this is not given."
             ),
             "default": None,
         },
@@ -470,8 +479,8 @@ class ZarrDataIO(DataIO):
     )
     def __init__(self, **kwargs):
         # TODO Need to add error checks and warnings to ZarrDataIO to check for parameter collisions and add tests
-        data, chunks, fill_value, compressor, filters, self.__link_data = getargs(
-            "data", "chunks", "fillvalue", "compressor", "filters", "link_data", kwargs
+        data, chunks, fill_value, compressors, filters, serializer, self.__link_data = getargs(
+            "data", "chunks", "fillvalue", "compressors", "filters", "serializer", "link_data", kwargs
         )
         # NOTE: dtype and shape of the DataIO base class are not yet supported by ZarrDataIO.
         #       These parameters are used to create empty data to allocate the data but
@@ -484,19 +493,21 @@ class ZarrDataIO(DataIO):
             self.__iosettings["chunks"] = chunks
         if fill_value is not None:
             self.__iosettings["fill_value"] = fill_value
-        if compressor is not None:
-            if isinstance(compressor, bool):
+        if compressors is not None:
+            if isinstance(compressors, bool):
                 # Disable compression by setting compressors to empty list
-                if not compressor:
+                if not compressors:
                     self.__iosettings["compressors"] = None
                 # To use default settings simply do not specify any compressor settings
                 else:
                     pass
             # use the user-specified compressor(s)
             else:
-                self.__iosettings["compressors"] = compressor
+                self.__iosettings["compressors"] = compressors
         if filters is not None:
             self.__iosettings["filters"] = list(filters)
+        if serializer is not None:
+            self.__iosettings["serializer"] = serializer
 
     @property
     def link_data(self) -> bool:
@@ -538,15 +549,9 @@ class ZarrDataIO(DataIO):
         if isinstance(fillval, bytes):  # bytes are not JSON serializable so use string instead
             fillval = fillval.decode("utf-8")
         chunks = h5dataset.chunks if "chunks" not in kwargs else kwargs.pop("chunks")
-        if len(compressors) == 1:
-            compressor = compressors[0]
-        elif len(compressors) > 1:
-            compressor = compressors
-        else:
-            compressor = None
         re = ZarrDataIO(
             data=h5dataset,
-            compressor=compressor,
+            compressors=compressors if compressors else None,
             filters=filters if filters else None,
             fillvalue=fillval,
             chunks=chunks,

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -613,13 +613,13 @@ class BaseTestZarrWriteUnit(BaseZarrWriterTestCase):
     #############################################
     def test_zarrdataio_enable_default_compressor(self):
         """Default compression simply means not specifying any compressor and using Zarr defaults"""
-        dataio = ZarrDataIO(np.arange(30).reshape(5, 2, 3), compressor=True)
+        dataio = ZarrDataIO(np.arange(30).reshape(5, 2, 3), compressors=True)
         self.assertEqual(len(dataio.io_settings), 0)
 
     def test_zarrdataio_disable_compressor(self):
         """Test that ZarrDataIO.__array__ is working when wrapping an ndarray"""
         test_speed = np.array([10.0, 20.0])
-        data = ZarrDataIO((test_speed), compressor=False)
+        data = ZarrDataIO((test_speed), compressors=False)
         self.assertIsNone(data.io_settings["compressors"])
 
     def test_zarrdataio_array_conversion_numpy(self):
@@ -859,7 +859,7 @@ class BaseTestZarrWriteUnit(BaseZarrWriterTestCase):
     @unittest.skipIf(DISABLE_ZARR_COMPRESSION_TESTS, "Skip test due to zarr codecs not available")
     def test_write_dataset_list_compress(self):
         compressor = BloscCodec(cname="zstd", clevel=3, shuffle="bitshuffle")
-        a = ZarrDataIO(np.arange(30).reshape(5, 2, 3), compressor=compressor)
+        a = ZarrDataIO(np.arange(30).reshape(5, 2, 3), compressors=compressor)
         tempIO = ZarrIO(self.store_path, mode="w")
         tempIO.open()
         tempIO.write_dataset(tempIO._file, DatasetBuilder("test_dataset", a, attributes={}))
@@ -872,7 +872,7 @@ class BaseTestZarrWriteUnit(BaseZarrWriterTestCase):
     def test_write_dataset_list_compress_and_filter(self):
         compressor = BloscCodec(cname="zstd", clevel=3, shuffle="bitshuffle")
         filters = [TransposeCodec(order=(2, 1, 0))]
-        a = ZarrDataIO(np.arange(30, dtype="i4").reshape(5, 2, 3), compressor=compressor, filters=filters)
+        a = ZarrDataIO(np.arange(30, dtype="i4").reshape(5, 2, 3), compressors=compressor, filters=filters)
         tempIO = ZarrIO(self.store_path, mode="w")
         tempIO.open()
         tempIO.write_dataset(tempIO._file, DatasetBuilder("test_dataset", a, attributes={}))
@@ -957,7 +957,7 @@ class BaseTestZarrWriteUnit(BaseZarrWriterTestCase):
         aiter = iter(a)
         daiter = DataChunkIterator.from_iterable(aiter, buffer_size=2)
         compressor = BloscCodec(cname="zstd", clevel=3, shuffle="bitshuffle")
-        wrapped_daiter = ZarrDataIO(data=daiter, compressor=compressor)
+        wrapped_daiter = ZarrDataIO(data=daiter, compressors=compressor)
         tempIO = ZarrIO(self.store_path, mode="w")
         tempIO.open()
         tempIO.write_dataset(tempIO._file, DatasetBuilder("test_dataset", wrapped_daiter, attributes={}))
@@ -979,7 +979,7 @@ class BaseTestZarrWriteUnit(BaseZarrWriterTestCase):
     def test_write_dataset_data_chunk_iterator_with_compression(self):
         dci = DataChunkIterator(data=np.arange(10), buffer_size=2)
         compressor = BloscCodec(cname="zstd", clevel=3, shuffle="bitshuffle")
-        wrapped_dci = ZarrDataIO(data=dci, compressor=compressor, chunks=(2,))
+        wrapped_dci = ZarrDataIO(data=dci, compressors=compressor, chunks=(2,))
         tempIO = ZarrIO(self.store_path, mode="w")
         tempIO.open()
         tempIO.write_dataset(tempIO._file, DatasetBuilder("test_dataset", wrapped_dci, attributes={}))
@@ -997,7 +997,7 @@ class BaseTestZarrWriteUnit(BaseZarrWriterTestCase):
 
         dci = DC(data=np.arange(30).reshape(5, 2, 3))
         compressor = BloscCodec(cname="zstd", clevel=3, shuffle="bitshuffle")
-        wrapped_dci = ZarrDataIO(data=dci, compressor=compressor)
+        wrapped_dci = ZarrDataIO(data=dci, compressors=compressor)
         tempIO = ZarrIO(self.store_path, mode="w")
         tempIO.open()
         tempIO.write_dataset(tempIO._file, DatasetBuilder("test_dataset", wrapped_dci, attributes={}))

--- a/tests/unit/test_compression_info.py
+++ b/tests/unit/test_compression_info.py
@@ -38,7 +38,7 @@ class TestZarrCompressionInfo(unittest.TestCase):
         data_io = ZarrDataIO(
             data=data,
             chunks=(10, 10),
-            compressor=compressor,
+            compressors=compressor,
         )
 
         # Write data with ZarrIO
@@ -79,7 +79,7 @@ class TestZarrCompressionInfo(unittest.TestCase):
         data_io = ZarrDataIO(
             data=data,
             chunks=(10, 10),
-            compressor=compressor,
+            compressors=compressor,
         )
 
         # Write data with ZarrIO without consolidation
@@ -120,7 +120,7 @@ class TestZarrCompressionInfo(unittest.TestCase):
         data_io = ZarrDataIO(
             data=data,
             chunks=(10, 10),
-            compressor=compressor,
+            compressors=compressor,
         )
 
         # Write data with ZarrIO with consolidated metadata


### PR DESCRIPTION
Zarr v3 splits the codec pipeline into three slots and fixes the type each one takes:

* `filters`, `ArrayArrayCodec`: transform the array into another array before anything is serialized, e.g. `TransposeCodec`.
* `serializer`, `ArrayBytesCodec`: encode that array into bytes. There is exactly one, e.g. `BytesCodec` for numeric data or `VLenUTF8Codec` for strings.
* `compressors`, `BytesBytesCodec`: transform those bytes, e.g. `BloscCodec` or `ZstdCodec`. `Shuffle` lives here now, where in v2 it was a filter.

`ZarrDataIO` takes `compressor` and `filters`. `compressor` is singular but its type is already `(BytesBytesCodec, list, bool)`, `filters` keeps the v2 name for something that means less than it used to, and the serializer slot cannot be reached at all, so there is no way to say how an array is encoded to bytes. This PR renames `compressor` to `compressors`, adds `serializer` and leaves `filters` alone, so the three names and their meanings are the ones `zarr.Group.create_array` already takes. I would rather not have people learn a second vocabulary to configure a zarr dataset, and the serializer slot becomes reachable.

I did not keep `compressor` as a deprecated alias. The release is breaking anyway, and a v2 codec object passed to it does not work on v3 either, so the alias would carry the old name forward without saving anyone. Passing it now raises `TypeError: ZarrDataIO.__init__: unrecognized argument: 'compressor'`. I hit the missing slots from the other side in neuroconv, where the configuration models carry an ordered `compressors` list and `get_data_io_kwargs()` has to flatten it back into a single compressor because that is all `ZarrDataIO` accepts:
https://github.com/catalystneuro/neuroconv/pull/1979
