### PR TITLE
Add `shards` argument to `ZarrDataIO`

### DIFF
--- a/src/hdmf_zarr/utils.py
+++ b/src/hdmf_zarr/utils.py
@@ -517,7 +517,10 @@ class ZarrDataIO(DataIO):
         {
             "name": "chunks",
             "type": (list, tuple),
-            "doc": "Chunk shape",
+            "doc": (
+                "Chunk shape. When ``shards`` is also specified, ``chunks`` defines the inner chunk shape "
+                "within each shard (i.e. the fine-grained I/O unit)."
+            ),
             "default": None,
         },
         {
@@ -555,6 +558,17 @@ class ZarrDataIO(DataIO):
             "default": None,
         },
         {
+            "name": "shards",
+            "type": (list, tuple),
+            "doc": (
+                "Shard shape for use with Zarr's sharding storage transformer. Each shard is a single object "
+                "in the store and contains multiple inner chunks defined by ``chunks``. Sharding reduces the "
+                "number of store objects and can improve performance for large arrays. Requires ``chunks`` to "
+                "define the inner chunk shape within each shard."
+            ),
+            "default": None,
+        },
+        {
             "name": "link_data",
             "type": bool,
             "doc": (
@@ -566,8 +580,8 @@ class ZarrDataIO(DataIO):
     )
     def __init__(self, **kwargs):
         # TODO Need to add error checks and warnings to ZarrDataIO to check for parameter collisions and add tests
-        data, chunks, fill_value, compressors, filters, serializer, self.__link_data = getargs(
-            "data", "chunks", "fillvalue", "compressors", "filters", "serializer", "link_data", kwargs
+        data, chunks, fill_value, compressors, filters, serializer, shards, self.__link_data = getargs(
+            "data", "chunks", "fillvalue", "compressors", "filters", "serializer", "shards", "link_data", kwargs
         )
         # NOTE: dtype and shape of the DataIO base class are not yet supported by ZarrDataIO.
         #       These parameters are used to create empty data to allocate the data but
@@ -595,6 +609,27 @@ class ZarrDataIO(DataIO):
             self.__iosettings["filters"] = list(filters)
         if serializer is not None:
             self.__iosettings["serializer"] = serializer
+        if shards is not None:
+            self.__iosettings["shards"] = tuple(shards)
+        if shards is not None and chunks is None:
+            warn(
+                "Specifying 'shards' without 'chunks' is not recommended. "
+                "When using sharding, 'chunks' defines the inner chunk shape within each shard.",
+                UserWarning,
+                stacklevel=2,
+            )
+        elif shards is not None and chunks is not None:
+            if len(shards) != len(chunks):
+                raise ValueError(
+                    f"'shards' and 'chunks' must have the same number of dimensions, "
+                    f"but got len(shards)={len(shards)} and len(chunks)={len(chunks)}."
+                )
+            for i, (s, c) in enumerate(zip(shards, chunks)):
+                if s % c != 0:
+                    raise ValueError(
+                        f"Shard shape dimension {i} (shards[{i}]={s}) must be a multiple of "
+                        f"the chunk shape dimension {i} (chunks[{i}]={c})."
+                    )
 
     @property
     def link_data(self) -> bool:

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -890,6 +890,26 @@ class BaseTestZarrWriteUnit(BaseZarrWriterTestCase):
         self.assertEqual(len(dset.filters), len(filters))
         tempIO.close()
 
+    def test_write_dataset_list_sharded(self):
+        """Test that ZarrDataIO with shards writes a sharded Zarr array and data round-trips correctly."""
+        from zarr.codecs import ShardingCodec
+
+        data = np.arange(1000, dtype="i4").reshape(100, 10)
+        a = ZarrDataIO(data, chunks=(10, 5), shards=(50, 10))
+        tempIO = ZarrIO(self.store_path, mode="w")
+        tempIO.open()
+        tempIO.write_dataset(tempIO._file, DatasetBuilder("test_dataset", a, attributes={}))
+        dset = tempIO._file["test_dataset"]
+        # Data round-trip is correct
+        self.assertTrue(np.all(dset[:] == data))
+        # The inner chunk shape (exposed via dset.chunks in zarr v3) matches chunks=
+        self.assertEqual(tuple(dset.chunks), (10, 5))
+        # ShardingCodec is present in the codec pipeline; shard shape is the outer chunk grid
+        codec_list = list(dset.metadata.codecs)
+        self.assertTrue(any(isinstance(c, ShardingCodec) for c in codec_list))
+        self.assertEqual(tuple(dset.metadata.chunk_grid.chunk_shape), (50, 10))
+        tempIO.close()
+
     ##########################################
     #  write_dataset tests: Iterable
     ##########################################

--- a/tests/unit/test_zarrdataio.py
+++ b/tests/unit/test_zarrdataio.py
@@ -285,3 +285,30 @@ class TestZarrDataIO(TestCase):
         z = zarr.zeros(shape=(10000, 10000), chunks=(1000, 1000), dtype="int32")
         io = ZarrDataIO(z, link_data=True)
         assert io.get_io_params().get("link_data")
+
+
+class TestZarrDataIOSharding(TestCase):
+    """Unit tests for ZarrDataIO sharding parameter validation."""
+
+    def test_shards_and_chunks_stored_in_io_settings(self):
+        """Test that valid shards+chunks are stored in io_settings without error."""
+        data = np.arange(1000, dtype="i4").reshape(100, 10)
+        io = ZarrDataIO(data, chunks=(10, 5), shards=(50, 10))
+        self.assertEqual(io.io_settings["shards"], (50, 10))
+        self.assertEqual(io.io_settings["chunks"], (10, 5))
+
+    def test_shards_without_chunks_warns(self):
+        """Test that a UserWarning is raised when shards is set without chunks."""
+        data = np.arange(1000, dtype="i4").reshape(100, 10)
+        msg = (
+            "Specifying 'shards' without 'chunks' is not recommended. "
+            "When using sharding, 'chunks' defines the inner chunk shape within each shard."
+        )
+        with self.assertWarnsWith(UserWarning, msg):
+            ZarrDataIO(data, shards=(50, 10))
+
+    def test_shards_not_multiple_of_chunks_raises(self):
+        """Test that ValueError is raised when a shard dimension is not a multiple of the chunk dimension."""
+        data = np.arange(1000, dtype="i4").reshape(100, 10)
+        with self.assertRaises(ValueError):
+            ZarrDataIO(data, chunks=(10, 3), shards=(50, 10))


### PR DESCRIPTION
## Motivation

Zarr v3 comes with sharding, let's use it! 

On top of #325, this PR simply adds `shards` to the `__iosettings`, plus some consistency checks with chunks.

Added a minimal set of tests