### PR TITLE
Fix #371 Increase Zarr and Python minimum versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -56,8 +56,6 @@ body:
         - "3.14"
         - "3.13"
         - "3.12"
-        - "3.11"
-        - "3.10"
         - older (please specify in "Package Versions" below)
     validations:
       required: true

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -25,22 +25,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.11-minimum     , test-tox-env: py311-minimum   , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-python3.11             , test-tox-env: py311           , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.12-minimum     , test-tox-env: py312-minimum   , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-python3.12             , test-tox-env: py312           , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-python3.13             , test-tox-env: py313           , python-ver: "3.13", os: ubuntu-latest }
           - { name: linux-python3.14             , test-tox-env: py314           , python-ver: "3.14", os: ubuntu-latest }
           - { name: linux-python3.14-optional    , test-tox-env: py314-optional  , python-ver: "3.14", os: ubuntu-latest }
           - { name: linux-python3.14-prerelease  , test-tox-env: py314-prerelease, python-ver: "3.14", os: ubuntu-latest }
-          - { name: windows-python3.11-minimum   , test-tox-env: py311-minimum   , python-ver: "3.11", os: windows-latest }
-          - { name: windows-python3.11           , test-tox-env: py311           , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.12-minimum   , test-tox-env: py312-minimum   , python-ver: "3.12", os: windows-latest }
           - { name: windows-python3.12           , test-tox-env: py312           , python-ver: "3.12", os: windows-latest }
           - { name: windows-python3.13           , test-tox-env: py313           , python-ver: "3.13", os: windows-latest }
           - { name: windows-python3.14           , test-tox-env: py314           , python-ver: "3.14", os: windows-latest }
           - { name: windows-python3.14-optional  , test-tox-env: py314-optional  , python-ver: "3.14", os: windows-latest }
           - { name: windows-python3.14-prerelease, test-tox-env: py314-prerelease, python-ver: "3.14", os: windows-latest }
-          - { name: macos-python3.11-minimum     , test-tox-env: py311-minimum   , python-ver: "3.11", os: macos-15-intel }
-          - { name: macos-python3.11             , test-tox-env: py311           , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.12-minimum     , test-tox-env: py312-minimum   , python-ver: "3.12", os: macos-15-intel }
           - { name: macos-python3.12             , test-tox-env: py312           , python-ver: "3.12", os: macos-latest }
           - { name: macos-python3.13             , test-tox-env: py313           , python-ver: "3.13", os: macos-latest }
           - { name: macos-python3.13-optional    , test-tox-env: py313-optional  , python-ver: "3.13", os: macos-latest }
@@ -97,13 +94,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-gallery-python3.11-minimum     , test-tox-env: gallery-py311-minimum   , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-gallery-python3.12-minimum     , test-tox-env: gallery-py312-minimum   , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-gallery-python3.14-optional    , test-tox-env: gallery-py314-optional  , python-ver: "3.14", os: ubuntu-latest }
           - { name: linux-gallery-python3.14-prerelease  , test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: ubuntu-latest }
-          - { name: windows-gallery-python3.11-minimum   , test-tox-env: gallery-py311-minimum   , python-ver: "3.11", os: windows-latest }
+          - { name: windows-gallery-python3.12-minimum   , test-tox-env: gallery-py312-minimum   , python-ver: "3.12", os: windows-latest }
           - { name: windows-gallery-python3.14-optional  , test-tox-env: gallery-py314-optional  , python-ver: "3.14", os: windows-latest }
           - { name: windows-gallery-python3.14-prerelease, test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: windows-latest }
-          - { name: macos-gallery-python3.11-minimum     , test-tox-env: gallery-py311-minimum   , python-ver: "3.11", os: macos-15-intel }
+          - { name: macos-gallery-python3.12-minimum     , test-tox-env: gallery-py312-minimum   , python-ver: "3.12", os: macos-15-intel }
           - { name: macos-gallery-python3.13-optional    , test-tox-env: gallery-py313-optional  , python-ver: "3.13", os: macos-latest }
           - { name: macos-gallery-python3.13-prerelease  , test-tox-env: gallery-py313-prerelease, python-ver: "3.13", os: macos-latest }
           # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest
@@ -144,8 +141,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.11-minimum   , test-tox-env: py311-minimum   , python-ver: "3.11", os: ubuntu-latest }
-          - { name: conda-linux-python3.11           , test-tox-env: py311           , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.12-minimum   , test-tox-env: py312-minimum   , python-ver: "3.12", os: ubuntu-latest }
           - { name: conda-linux-python3.12           , test-tox-env: py312           , python-ver: "3.12", os: ubuntu-latest }
           - { name: conda-linux-python3.13           , test-tox-env: py313           , python-ver: "3.13", os: ubuntu-latest }
           - { name: conda-linux-python3.14           , test-tox-env: py314           , python-ver: "3.14", os: ubuntu-latest }

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,13 +19,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.11-minimum   , test-tox-env: py311-minimum , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.12-minimum   , test-tox-env: py312-minimum , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-python3.14           , test-tox-env: py314         , python-ver: "3.14", os: ubuntu-latest }
           - { name: linux-python3.14-optional  , test-tox-env: py314-optional, python-ver: "3.14", os: ubuntu-latest }
-          - { name: windows-python3.11-minimum , test-tox-env: py311-minimum , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.12-minimum , test-tox-env: py312-minimum , python-ver: "3.12", os: windows-latest }
           - { name: windows-python3.14         , test-tox-env: py314         , python-ver: "3.14", os: windows-latest }
           - { name: windows-python3.14-optional, test-tox-env: py314-optional, python-ver: "3.14", os: windows-latest }
-          - { name: macos-python3.11-minimum   , test-tox-env: py311-minimum , python-ver: "3.11", os: macos-15-intel }
+          - { name: macos-python3.12-minimum   , test-tox-env: py312-minimum , python-ver: "3.12", os: macos-15-intel }
           - { name: macos-python3.13           , test-tox-env: py313         , python-ver: "3.13", os: macos-latest }
           - { name: macos-python3.13-optional  , test-tox-env: py313-optional, python-ver: "3.13", os: macos-latest }
           # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest
@@ -79,9 +79,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-gallery-python3.11-minimum   , test-tox-env: gallery-py311-minimum , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-gallery-python3.12-minimum   , test-tox-env: gallery-py312-minimum , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-gallery-python3.14-optional  , test-tox-env: gallery-py314-optional, python-ver: "3.14", os: ubuntu-latest }
-          - { name: windows-gallery-python3.11-minimum , test-tox-env: gallery-py311-minimum , python-ver: "3.11", os: windows-latest }
+          - { name: windows-gallery-python3.12-minimum , test-tox-env: gallery-py312-minimum , python-ver: "3.12", os: windows-latest }
           - { name: windows-gallery-python3.14-optional, test-tox-env: gallery-py314-optional, python-ver: "3.14", os: windows-latest }
     steps:
       - name: Checkout repo
@@ -117,7 +117,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.11-minimum , test-tox-env: py311-minimum , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.12-minimum , test-tox-env: py312-minimum , python-ver: "3.12", os: ubuntu-latest }
           - { name: conda-linux-python3.14         , test-tox-env: py314         , python-ver: "3.14", os: ubuntu-latest }
           - { name: conda-linux-python3.14-optional, test-tox-env: py314-optional, python-ver: "3.14", os: ubuntu-latest }
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added a clear error when reading a Zarr v2 file with the Zarr v3 `ZarrIO`/`NWBZarrIO` that directs the user to `ZarrV2IO`/`NWBZarrV2IO`, replacing an opaque zarr-python parse error. @alejoe91 [#349](https://github.com/hdmf-dev/hdmf-zarr/pull/349)
 
 ### Changed
+- Bumped minimum required Python version from 3.11 to 3.12 and Zarr dependency to `>=3.3.0` due to backwards-incompatible changes in Zarr v3 structured data types. [#373](https://github.com/hdmf-dev/hdmf-zarr/pull/373)
 - Aligned `ZarrDataIO` with the zarr v3 codec API: `compressor` is renamed to `compressors`, the `serializer` (`ArrayBytesCodec`) slot is now reachable, and `filters` keeps its name for `ArrayArrayCodec` only. @h-mayorquin [#369](https://github.com/hdmf-dev/hdmf-zarr/pull/369)
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,10 @@ authors = [
 ]
 description = "A package defining a Zarr I/O backend for HDMF"
 readme = "README.rst"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = {text = "BSD"}
 classifiers = [
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -31,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "hdmf>=6.2.0",  # 6.2.0 reads a zarr array into memory before the HDF5 write, which avoids a deadlock when exporting to HDF5
-    "zarr>=3.1.3",
+    "zarr>=3.3.0",
     "numpy>=2.0.0",
     "numcodecs>=0.14.0",
     "pynwb>=4.2.0",  # pynwb 3.x requires hdmf<5

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 [tox]
 # NOTE: if the string "py311" is in the environment name, then the py311 interpreter is used,
 # so we can omit specifying the basepython version below.
-envlist = py311, py312, py313, py314
+envlist = py312, py313, py314
 requires = pip >= 24.3.1
 
 [testenv]
@@ -32,7 +32,7 @@ commands =
     coverage html -d tests/coverage/htmlcov
 
 # Envs that run tests
-[testenv:py{310,311,312,313,314}]
+[testenv:py{312,313,314}]
 commands = {[testenv]commands}
 
 # Test with python 3.13 and all optional dependencies
@@ -63,10 +63,10 @@ extras = full
 dependency_groups = {[testenv]dependency_groups}
 commands = {[testenv]commands}
 
-# Test with python 3.11 and minimum dependencies
+# Test with python 3.12 and minimum dependencies
 # Uses uv with --resolution lowest-direct to install the lowest compatible
 # versions of direct dependencies, replacing the old requirements-min.txt approach.
-[testenv:py311-minimum]
+[testenv:py312-minimum]
 skip_install = True
 dependency_groups = test
 commands_pre =
@@ -101,7 +101,7 @@ commands =
     python -m pip check
     python test_gallery.py
 
-[testenv:gallery-{py311,py312,py313,py314}]
+[testenv:gallery-{py312,py313,py314}]
 commands = {[testenv:gallery]commands}
 
 # Test with python 3.13 and all optional dependencies
@@ -132,8 +132,8 @@ extras = full
 dependency_groups = docs
 commands = {[testenv:gallery]commands}
 
-# Test with python 3.11 and minimum dependencies
-[testenv:gallery-py311-minimum]
+# Test with python 3.12 and minimum dependencies
+[testenv:gallery-py312-minimum]
 skip_install = True
 dependency_groups = test
 commands_pre =


### PR DESCRIPTION
Fix #371 


1. __`pyproject.toml`__:

   - Updated `requires-python` from `>=3.11` to `>=3.12`.
   - Removed the Python 3.11 Trove classifier.
   - Updated the Zarr version pin from `zarr>=3.1.3` to `zarr>=3.3.0`.

2. __`tox.ini`__:

   - Dropped `py311` from the main `envlist` and environment groupings (e.g. replacing `py{310,311,312,313,314}` with `py{312,313,314}`).
   - Renamed and reconfigured the `py311-minimum` and `gallery-py311-minimum` test environments to run on Python 3.12 (`py312-minimum` and `gallery-py312-minimum`).

3. __GitHub Actions (`.github/workflows/run_tests.yml` & `.github/workflows/run_all_tests.yml`)__:

   - Purged all `python3.11` test entries from the matrices across all platforms (Ubuntu, Windows, and macOS).
   - Changed the `-minimum` dependencies jobs (e.g. `linux-python3.11-minimum`, `conda-linux-python3.11-minimum`, etc.) to run on Python 3.12 (`*python3.12-minimum`).

4. __Bug Report Issue Template (`.github/ISSUE_TEMPLATE/bug_report.yml`)__:
   - Removed `"3.11"` and `"3.10"` from the available options in the Python version dropdown.



## Checklist

- [X] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-zarr/blob/dev/docs/CONTRIBUTING.rst)?
- [X] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?