### PR TITLE
Prevent data loss in parallel writes to sharded arrays

### DIFF
--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -436,8 +436,11 @@ class ZarrIO(HDMFIO):
             "name": "number_of_jobs",
             "type": int,
             "doc": (
-                "Number of jobs to use in parallel during write "
-                "(only works with GenericDataChunkIterator-wrapped datasets)."
+                "Number of worker processes to use in parallel during write "
+                "(only works with GenericDataChunkIterator-wrapped datasets). For sharded arrays, "
+                "parallel tasks own separate shards. Shard and iterator buffer shapes therefore affect "
+                "the number of independent tasks and available parallelism. See the ZarrDataIO ``shards`` parameter for "
+                "buffer alignment and memory guidance."
             ),
             "default": 1,
         },
@@ -517,8 +520,11 @@ class ZarrIO(HDMFIO):
             "name": "number_of_jobs",
             "type": int,
             "doc": (
-                "Number of jobs to use in parallel during write "
-                "(only works with GenericDataChunkIterator-wrapped datasets)."
+                "Number of worker processes to use in parallel during write "
+                "(only works with GenericDataChunkIterator-wrapped datasets). For sharded arrays, "
+                "parallel tasks own separate shards. Shard and iterator buffer shapes therefore affect "
+                "the number of independent tasks and available parallelism. See the ZarrDataIO ``shards`` parameter for "
+                "buffer alignment and memory guidance."
             ),
             "default": 1,
         },

--- a/src/hdmf_zarr/backend.py
+++ b/src/hdmf_zarr/backend.py
@@ -439,8 +439,8 @@ class ZarrIO(HDMFIO):
                 "Number of worker processes to use in parallel during write "
                 "(only works with GenericDataChunkIterator-wrapped datasets). For sharded arrays, "
                 "parallel tasks own separate shards. Shard and iterator buffer shapes therefore affect "
-                "the number of independent tasks and available parallelism. See the ZarrDataIO ``shards`` parameter for "
-                "buffer alignment and memory guidance."
+                "the number of independent tasks and available parallelism. See the ZarrDataIO ``shards`` parameter "
+                "for buffer alignment and memory guidance."
             ),
             "default": 1,
         },
@@ -523,8 +523,8 @@ class ZarrIO(HDMFIO):
                 "Number of worker processes to use in parallel during write "
                 "(only works with GenericDataChunkIterator-wrapped datasets). For sharded arrays, "
                 "parallel tasks own separate shards. Shard and iterator buffer shapes therefore affect "
-                "the number of independent tasks and available parallelism. See the ZarrDataIO ``shards`` parameter for "
-                "buffer alignment and memory guidance."
+                "the number of independent tasks and available parallelism. See the ZarrDataIO ``shards`` parameter "
+                "for buffer alignment and memory guidance."
             ),
             "default": 1,
         },

--- a/src/hdmf_zarr/utils.py
+++ b/src/hdmf_zarr/utils.py
@@ -7,6 +7,7 @@ import math
 import json
 import logging
 import os
+from itertools import product
 from collections import deque
 from collections.abc import Iterable
 from typing import Optional, Union, Literal, Tuple, Dict, Any
@@ -229,25 +230,6 @@ class ZarrIODataChunkIteratorQueue(deque):
                     )
                     continue
 
-                # GenericDataChunkIterator tiles from zero in buffer_shape steps. Each
-                # task must own whole shards, except at the outer array boundary.
-                # Inspect the created array because Zarr may have chosen shards="auto".
-                shards = zarr_dataset.shards
-                if shards is not None and any(
-                    buffer_size % shard_size != 0 and buffer_size != array_size
-                    for buffer_size, shard_size, array_size in zip(iterator.buffer_shape, shards, zarr_dataset.shape)
-                ):
-                    warn(
-                        f"Writing dataset '{zarr_dataset.path}' sequentially: iterator buffer shape "
-                        f"{iterator.buffer_shape} is not aligned with shard shape {shards}. "
-                        "Parallel writes could update the same shard and lose data. "
-                        "Use a buffer shape that is a multiple of the shard shape, "
-                        "or covers the entire array dimension.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
-                    continue
-
                 # Add this entry to a running list to remove after initial pass (cannot mutate during iteration)
                 parallelizable_iterators.append((zarr_dataset, iterator))
 
@@ -262,7 +244,15 @@ class ZarrIODataChunkIteratorQueue(deque):
                 progress_bar_options.update(**per_iterator_progress_options)
 
                 iterator_itemsize = iterator.dtype.itemsize
-                for buffer_selection in iterator.buffer_selection_generator:
+                # Preserve whole buffers when they own complete shards. Otherwise,
+                # give each shard one task, using Zarr's resolved layout for auto.
+                selections = (
+                    self._iter_shard_selections(zarr_dataset.shape, zarr_dataset.shards)
+                    if zarr_dataset.shards is not None
+                    and not self._buffers_contain_shards(zarr_dataset.shape, zarr_dataset.shards, iterator.buffer_shape)
+                    else iterator.buffer_selection_generator
+                )
+                for buffer_selection in selections:
                     store = zarr_dataset.store
                     store_path = str(store.root) if hasattr(store, "root") else str(store)
                     buffer_map_args = (store_path, zarr_dataset.path, iterator, buffer_selection)
@@ -392,6 +382,33 @@ class ZarrIODataChunkIteratorQueue(deque):
         _operation_to_run = operation_to_run
 
     @staticmethod
+    def _buffers_contain_shards(shape, shards, buffers):
+        """Return whether buffer boundaries avoid splitting destination shards."""
+        return all(buffer == size or buffer % shard == 0 for size, shard, buffer in zip(shape, shards, buffers))
+
+    @staticmethod
+    def _iter_shard_selections(shape, shards):
+        """Yield one non-overlapping task selection per destination shard."""
+        for start in product(*(range(0, size, shard) for size, shard in zip(shape, shards))):
+            yield tuple(slice(pos, min(pos + shard, size)) for pos, shard, size in zip(start, shards, shape))
+
+    @staticmethod
+    def _iter_shard_buffer_selections(shard_selection, buffer_shape):
+        """Intersect a shard with the iterator buffer grid without loading a full shard.
+
+        A buffer crossing shard boundaries is read in separate pieces by the shard
+        owners. Each requested piece is no larger than the iterator buffer shape.
+        """
+        starts = (
+            range(part.start // size * size, part.stop, size) for part, size in zip(shard_selection, buffer_shape)
+        )
+        for start in product(*starts):
+            yield tuple(
+                slice(max(pos, part.start), min(pos + size, part.stop))
+                for pos, size, part in zip(start, buffer_shape, shard_selection)
+            )
+
+    @staticmethod
     def _write_buffer_zarr(
         worker_context: Dict[str, Any],
         zarr_store_path: str,
@@ -403,12 +420,21 @@ class ZarrIODataChunkIteratorQueue(deque):
         zarr_store = zarr.open(store=zarr_store_path, mode="r+")  # storage_options=storage_options)
         zarr_dataset = zarr_store[relative_dataset_path]
 
-        data = iterator._get_data(selection=buffer_selection)
-        zarr_dataset[buffer_selection] = data
+        if zarr_dataset.shards is None:
+            selections = (buffer_selection,)
+        else:
+            # Whole-buffer tasks yield one read; shard tasks may yield several.
+            # Finish each write before updating another part of the owned shard.
+            selections = ZarrIODataChunkIteratorQueue._iter_shard_buffer_selections(
+                buffer_selection, iterator.buffer_shape
+            )
+        for selection in selections:
+            data = iterator._get_data(selection=selection)
+            zarr_dataset[selection] = data
+            del data
 
         # An issue detected in cloud usage by the SpikeInterface team
         # Fix memory leak by forcing garbage collection
-        del data
         gc.collect()
 
     @staticmethod
@@ -582,8 +608,8 @@ class ZarrDataIO(DataIO):
                 "Shard shape in array elements, or 'auto' to let Zarr choose the shape. Each shard is a single object "
                 "in the store and contains multiple inner chunks defined by ``chunks``. Sharding reduces the "
                 "number of store objects and can improve performance for large arrays. ``chunks`` defines the "
-                "inner chunk shape. Parallel iterator writes require buffers aligned with the resulting "
-                "shard shape, otherwise the dataset is written sequentially with a warning."
+                "inner chunk shape. Parallel iterator writes assign each shard to one task. Each task reads "
+                "and writes buffer-sized pieces sequentially within its shard."
             ),
             "default": None,
         },

--- a/src/hdmf_zarr/utils.py
+++ b/src/hdmf_zarr/utils.py
@@ -608,8 +608,14 @@ class ZarrDataIO(DataIO):
                 "Shard shape in array elements, or 'auto' to let Zarr choose the shape. Each shard is a single object "
                 "in the store and contains multiple inner chunks defined by ``chunks``. Sharding reduces the "
                 "number of store objects and can improve performance for large arrays. ``chunks`` defines the "
-                "inner chunk shape. Parallel iterator writes assign each shard to one task. Each task reads "
-                "and writes buffer-sized pieces sequentially within its shard."
+                "inner chunk shape. For efficient parallel iterator writes, prefer a ``buffer_shape`` equal to "
+                "the shard shape or an integer multiple along each axis, so each buffer contains complete shards. "
+                "Buffers spanning a full array axis may include a partial edge shard. Aligned buffers are written "
+                "as whole-buffer tasks. Other buffer shapes are supported safely by assigning each shard to one "
+                "task and reading the portions of iterator buffers inside it. Multiple partial writes to a shard "
+                "can repeatedly read and rewrite its existing contents. ``buffer_shape`` bounds source reads, "
+                "not Zarr's additional internal memory. With 'auto', scheduling uses the shard shape chosen by "
+                "Zarr; buffer-shard alignment is not required."
             ),
             "default": None,
         },

--- a/src/hdmf_zarr/utils.py
+++ b/src/hdmf_zarr/utils.py
@@ -246,6 +246,8 @@ class ZarrIODataChunkIteratorQueue(deque):
                 iterator_itemsize = iterator.dtype.itemsize
                 # Preserve whole buffers when they own complete shards. Otherwise,
                 # give each shard one task, using Zarr's resolved layout for auto.
+                # When a shard spans multiple iterator buffers, their intersections
+                # are read and written sequentially within the same task.
                 selections = (
                     self._iter_shard_selections(zarr_dataset.shape, zarr_dataset.shards)
                     if zarr_dataset.shards is not None
@@ -612,9 +614,12 @@ class ZarrDataIO(DataIO):
                 "the shard shape or an integer multiple along each axis, so each buffer contains complete shards. "
                 "Buffers spanning a full array axis may include a partial edge shard. Aligned buffers are written "
                 "as whole-buffer tasks. Other buffer shapes are supported safely by assigning each shard to one "
-                "task and reading the portions of iterator buffers inside it. Multiple partial writes to a shard "
-                "can repeatedly read and rewrite its existing contents. ``buffer_shape`` bounds source reads, "
-                "not Zarr's additional internal memory. With 'auto', scheduling uses the shard shape chosen by "
+                "task and sequentially reading and writing the portions of iterator buffers inside it. Partial "
+                "shard updates read the entire existing encoded shard and assemble its replacement. When "
+                "shards span multiple buffers, this repeats for successive buffer pieces and can use substantially "
+                "more memory than the source buffer. ``buffer_shape`` limits source read sizes, not total write "
+                "memory, including Zarr's encoded shard buffers and codec workspace. With 'auto', scheduling uses "
+                "the shard shape chosen by "
                 "Zarr; buffer-shard alignment is not required."
             ),
             "default": None,

--- a/src/hdmf_zarr/utils.py
+++ b/src/hdmf_zarr/utils.py
@@ -25,7 +25,6 @@ from hdmf.utils import docval, getargs
 
 from hdmf.spec import SpecWriter, SpecReader
 
-
 # Necessary definitions to avoid parallelization bugs, Inherited from SpikeInterface experience
 # see
 # https://stackoverflow.com/questions/10117073/how-to-use-initializer-to-set-up-my-multiprocess-pool
@@ -227,6 +226,25 @@ class ZarrIODataChunkIteratorQueue(deque):
                 if not is_iterator_pickleable:
                     self.logger.debug(
                         f"Dataset {zarr_dataset.path} was not pickleable during parallel write.\n\nReason: {reason}"
+                    )
+                    continue
+
+                # GenericDataChunkIterator tiles from zero in buffer_shape steps. Each
+                # task must own whole shards, except at the outer array boundary.
+                # Inspect the created array because Zarr may have chosen shards="auto".
+                shards = zarr_dataset.shards
+                if shards is not None and any(
+                    buffer_size % shard_size != 0 and buffer_size != array_size
+                    for buffer_size, shard_size, array_size in zip(iterator.buffer_shape, shards, zarr_dataset.shape)
+                ):
+                    warn(
+                        f"Writing dataset '{zarr_dataset.path}' sequentially: iterator buffer shape "
+                        f"{iterator.buffer_shape} is not aligned with shard shape {shards}. "
+                        "Parallel writes could update the same shard and lose data. "
+                        "Use a buffer shape that is a multiple of the shard shape, "
+                        "or covers the entire array dimension.",
+                        UserWarning,
+                        stacklevel=2,
                     )
                     continue
 
@@ -559,12 +577,13 @@ class ZarrDataIO(DataIO):
         },
         {
             "name": "shards",
-            "type": (list, tuple),
+            "type": (list, tuple, str),
             "doc": (
-                "Shard shape for use with Zarr's sharding storage transformer. Each shard is a single object "
+                "Shard shape in array elements, or 'auto' to let Zarr choose the shape. Each shard is a single object "
                 "in the store and contains multiple inner chunks defined by ``chunks``. Sharding reduces the "
-                "number of store objects and can improve performance for large arrays. Requires ``chunks`` to "
-                "define the inner chunk shape within each shard."
+                "number of store objects and can improve performance for large arrays. ``chunks`` defines the "
+                "inner chunk shape. Parallel iterator writes require buffers aligned with the resulting "
+                "shard shape, otherwise the dataset is written sequentially with a warning."
             ),
             "default": None,
         },
@@ -609,16 +628,20 @@ class ZarrDataIO(DataIO):
             self.__iosettings["filters"] = list(filters)
         if serializer is not None:
             self.__iosettings["serializer"] = serializer
-        if shards is not None:
+        if isinstance(shards, str):
+            if shards != "auto":
+                raise ValueError("'shards' must be a shape or 'auto'.")
+            self.__iosettings["shards"] = shards
+        elif shards is not None:
             self.__iosettings["shards"] = tuple(shards)
-        if shards is not None and chunks is None:
+        if shards is not None and not isinstance(shards, str) and chunks is None:
             warn(
                 "Specifying 'shards' without 'chunks' is not recommended. "
                 "When using sharding, 'chunks' defines the inner chunk shape within each shard.",
                 UserWarning,
                 stacklevel=2,
             )
-        elif shards is not None and chunks is not None:
+        elif shards is not None and not isinstance(shards, str) and chunks is not None:
             if len(shards) != len(chunks):
                 raise ValueError(
                     f"'shards' and 'chunks' must have the same number of dimensions, "
@@ -717,7 +740,7 @@ class ZarrDataIO(DataIO):
                 _warnings.filterwarnings("ignore", message="Numcodecs codecs are not in the Zarr")
                 if filter_id_str == "32001":
                     blosc_compressors = ("blosclz", "lz4", "lz4hc", "snappy", "zlib", "zstd")
-                    (_1, _2, bytes_per_num, total_bytes, clevel, shuffle, compressor) = properties
+                    _1, _2, bytes_per_num, total_bytes, clevel, shuffle, compressor = properties
                     pars = dict(
                         blocksize=total_bytes,
                         clevel=clevel,

--- a/tests/unit/base_tests_zarrio.py
+++ b/tests/unit/base_tests_zarrio.py
@@ -415,6 +415,7 @@ class BaseTestZarrWriter(BaseZarrWriterTestCase):
 
     def test_write_references_roundtrip(self):
         import json
+
         # Setup a file container with references
         num_bazs = 1
         bazs = []  # set up dataset of references
@@ -889,6 +890,18 @@ class BaseTestZarrWriteUnit(BaseZarrWriterTestCase):
         self.assertEqual(len(dset.compressors), 1)
         self.assertEqual(len(dset.filters), len(filters))
         tempIO.close()
+
+    def test_write_dataset_auto_shards(self):
+        data = np.arange(1000, dtype="i4").reshape(100, 10)
+        for name, chunks in (("inferred", None), ("explicit", (10, 5))):
+            with ZarrIO(self.store_path, mode="w") as io:
+                wrapped = ZarrDataIO(data, chunks=chunks, shards="auto")
+                io.write_dataset(io._file, DatasetBuilder(name, wrapped, attributes={}))
+                array = io._file[name]
+                self.assertIsNotNone(array.shards)
+                if chunks is not None:
+                    self.assertEqual(array.chunks, chunks)
+                np.testing.assert_array_equal(array[:], data)
 
     def test_write_dataset_list_sharded(self):
         """Test that ZarrDataIO with shards writes a sharded Zarr array and data round-trips correctly."""

--- a/tests/unit/test_parallel_write.py
+++ b/tests/unit/test_parallel_write.py
@@ -1,6 +1,7 @@
 """Module for testing the parallel write feature for the ZarrIO."""
 
 import unittest
+from itertools import product
 import platform
 import warnings
 from concurrent.futures import ProcessPoolExecutor
@@ -287,19 +288,29 @@ def test_extra_keyword_argument_propagation(tmpdir):
 
 
 @pytest.mark.parametrize(
-    "shape,chunks,shards,buffers,parallel",
+    "shape,chunks,shards,buffers",
     [
-        ((8,), (2,), (8,), (4,), False),
-        ((18,), (2,), (8,), (8,), True),
-        ((34,), (2,), (8,), (16,), True),
-        ((6,), (2,), (8,), (6,), True),
-        ((16, 12), (2, 2), (8, 8), (8, 4), False),
-        ((18, 6), (2, 2), (8, 8), (8, 6), True),
-        ((16,), (2,), None, (4,), True),
+        ((8,), (2,), (8,), (4,)),
+        ((22,), (2,), (8,), (6,)),
+        ((22, 14), (2, 2), (8, 8), (6, 10)),
+        ((18,), (2,), (8,), (8,)),
+        ((34,), (2,), (8,), (16,)),
+        ((6,), (2,), (8,), (6,)),
+        ((16, 12), (2, 2), (8, 8), (8, 4)),
+        ((18, 6), (2, 2), (8, 8), (8, 6)),
+        ((16,), (2,), None, (4,)),
     ],
 )
-def test_sharded_iterator_write_routing(tmp_path, shape, chunks, shards, buffers, parallel):
+def test_sharded_iterator_write_routing(tmp_path, shape, chunks, shards, buffers):
     """Check data and executor admission, without relying on a race occurring."""
+
+    tasks = []
+
+    class RecordingExecutor(ProcessPoolExecutor):
+        def map(self, fn, iterable, **kwargs):
+            items = list(iterable)
+            tasks.extend(items)
+            return super().map(fn, items, **kwargs)
 
     data = np.arange(1, np.prod(shape) + 1, dtype="int32").reshape(shape)
     iterator = PickleableDataChunkIterator(data, chunk_shape=chunks, buffer_shape=buffers)
@@ -308,19 +319,39 @@ def test_sharded_iterator_write_routing(tmp_path, shape, chunks, shards, buffers
     store = str(tmp_path / "data.zarr")
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        with patch("hdmf_zarr.utils.ProcessPoolExecutor", wraps=ProcessPoolExecutor) as executor:
+        with patch("hdmf_zarr.utils.ProcessPoolExecutor", wraps=RecordingExecutor) as executor:
             with ZarrIO(store, manager=get_manager(), mode="w") as io:
                 io.write(table, number_of_jobs=2, multiprocessing_context="spawn")
-    assert executor.called == parallel
+    assert executor.called
     fallback_warnings = [w for w in caught if "Writing dataset 'values' sequentially" in str(w.message)]
-    assert len(fallback_warnings) == (0 if parallel else 1)
+    assert not fallback_warnings
     array = zarr.open_group(store, mode="r")["values"]
     assert array.shards == shards
     assert_array_equal(array[:], data)
 
+    # Inspect actual submitted tasks: every cell is owned once, and no shard is
+    # touched by two tasks, even when the source buffers cross shard boundaries.
+    coverage = np.zeros(shape, dtype="int32")
+    shard_owners = set()
+    for _, path, _, selection in tasks:
+        assert path == "values"
+        coverage[selection] += 1
+        if shards is not None:
+            for shard_id in product(
+                *(range(part.start // size, (part.stop - 1) // size + 1) for part, size in zip(selection, shards))
+            ):
+                assert shard_id not in shard_owners
+                shard_owners.add(shard_id)
+    if shards is None or ZarrIODataChunkIteratorQueue._buffers_contain_shards(shape, shards, buffers):
+        expected = list(
+            PickleableDataChunkIterator(data, chunk_shape=chunks, buffer_shape=buffers).buffer_selection_generator
+        )
+        assert [task[3] for task in tasks] == expected
+    assert_array_equal(coverage, np.ones(shape, dtype="int32"))
+
 
 def test_mixed_shard_alignment(tmp_path):
-    """An unsafe dataset stays sequential while aligned datasets use workers."""
+    """Both aligned and misaligned buffers use shard-owned tasks."""
 
     data = np.arange(1, 17, dtype="int32")
     columns = [
@@ -343,11 +374,10 @@ def test_mixed_shard_alignment(tmp_path):
             "__write_chunk__",
             wraps=ZarrIODataChunkIteratorQueue.__write_chunk__,
         ) as sequential_write:
-            with pytest.warns(UserWarning, match="Writing dataset 'unsafe' sequentially"):
-                with ZarrIO(store, manager=get_manager(), mode="w") as io:
-                    io.write(table, number_of_jobs=2, multiprocessing_context="spawn")
+            with ZarrIO(store, manager=get_manager(), mode="w") as io:
+                io.write(table, number_of_jobs=2, multiprocessing_context="spawn")
     assert executor.called
-    assert {call.args[0].path for call in sequential_write.call_args_list} == {"unsafe"}
+    sequential_write.assert_not_called()
     group = zarr.open_group(store, mode="r")
     for name in ("unsafe", "safe"):
         assert_array_equal(group[name][:], data)
@@ -372,7 +402,23 @@ def test_auto_shards_iterator(tmp_path):
                 io.write(table, number_of_jobs=2, multiprocessing_context="spawn")
     array = zarr.open_group(store, mode="r")["values"]
     assert array.shards is not None
-    assert executor.called == (array.shards == (2,))
+    assert executor.called
     fallback = [w for w in caught if "Writing dataset 'values' sequentially" in str(w.message)]
-    assert len(fallback) == (0 if executor.called else 1)
+    assert not fallback
     assert_array_equal(array[:], data)
+
+
+@pytest.mark.parametrize(
+    "shape,shards,buffers",
+    [((22,), (8,), (6,)), ((22, 14), (8, 8), (6, 10)), ((18, 6), (8, 8), (8, 6))],
+)
+def test_shard_buffer_pieces(shape, shards, buffers):
+    """Source reads partition the data and never exceed the buffer dimensions."""
+    coverage = np.zeros(shape, dtype="int32")
+    for shard in ZarrIODataChunkIteratorQueue._iter_shard_selections(shape, shards):
+        for piece in ZarrIODataChunkIteratorQueue._iter_shard_buffer_selections(shard, buffers):
+            for selection, owner, limit in zip(piece, shard, buffers):
+                assert owner.start <= selection.start < selection.stop <= owner.stop
+                assert selection.stop - selection.start <= limit
+            coverage[piece] += 1
+    assert_array_equal(coverage, np.ones(shape, dtype="int32"))

--- a/tests/unit/test_parallel_write.py
+++ b/tests/unit/test_parallel_write.py
@@ -2,13 +2,18 @@
 
 import unittest
 import platform
+import warnings
+from concurrent.futures import ProcessPoolExecutor
 from typing import Tuple, Dict
 from io import StringIO
 from unittest.mock import patch
 
+import pytest
+import zarr
 import numpy as np
 from numpy.testing import assert_array_equal
-from hdmf_zarr import ZarrIO
+from hdmf_zarr import ZarrIO, ZarrDataIO
+from hdmf_zarr.utils import ZarrIODataChunkIteratorQueue
 from hdmf.common import DynamicTable, VectorData, get_manager
 from hdmf.data_utils import GenericDataChunkIterator, DataChunkIterator
 
@@ -279,3 +284,95 @@ def test_extra_keyword_argument_propagation(tmpdir):
 
             assert io._ZarrIO__dci_queue.max_threads_per_process == test_max_threads_per_process
             assert io._ZarrIO__dci_queue.multiprocessing_context == test_multiprocessing_context
+
+
+@pytest.mark.parametrize(
+    "shape,chunks,shards,buffers,parallel",
+    [
+        ((8,), (2,), (8,), (4,), False),
+        ((18,), (2,), (8,), (8,), True),
+        ((34,), (2,), (8,), (16,), True),
+        ((6,), (2,), (8,), (6,), True),
+        ((16, 12), (2, 2), (8, 8), (8, 4), False),
+        ((18, 6), (2, 2), (8, 8), (8, 6), True),
+        ((16,), (2,), None, (4,), True),
+    ],
+)
+def test_sharded_iterator_write_routing(tmp_path, shape, chunks, shards, buffers, parallel):
+    """Check data and executor admission, without relying on a race occurring."""
+
+    data = np.arange(1, np.prod(shape) + 1, dtype="int32").reshape(shape)
+    iterator = PickleableDataChunkIterator(data, chunk_shape=chunks, buffer_shape=buffers)
+    column = VectorData(name="values", description="", data=ZarrDataIO(iterator, chunks=chunks, shards=shards))
+    table = DynamicTable(name="table", description="", id=list(range(shape[0])), columns=[column])
+    store = str(tmp_path / "data.zarr")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with patch("hdmf_zarr.utils.ProcessPoolExecutor", wraps=ProcessPoolExecutor) as executor:
+            with ZarrIO(store, manager=get_manager(), mode="w") as io:
+                io.write(table, number_of_jobs=2, multiprocessing_context="spawn")
+    assert executor.called == parallel
+    fallback_warnings = [w for w in caught if "Writing dataset 'values' sequentially" in str(w.message)]
+    assert len(fallback_warnings) == (0 if parallel else 1)
+    array = zarr.open_group(store, mode="r")["values"]
+    assert array.shards == shards
+    assert_array_equal(array[:], data)
+
+
+def test_mixed_shard_alignment(tmp_path):
+    """An unsafe dataset stays sequential while aligned datasets use workers."""
+
+    data = np.arange(1, 17, dtype="int32")
+    columns = [
+        VectorData(
+            name=name,
+            description="",
+            data=ZarrDataIO(
+                PickleableDataChunkIterator(data, chunk_shape=(2,), buffer_shape=buffer),
+                chunks=(2,),
+                shards=(8,),
+            ),
+        )
+        for name, buffer in (("unsafe", (4,)), ("safe", (8,)))
+    ]
+    table = DynamicTable(name="table", description="", id=list(range(16)), columns=columns)
+    store = str(tmp_path / "mixed.zarr")
+    with patch("hdmf_zarr.utils.ProcessPoolExecutor", wraps=ProcessPoolExecutor) as executor:
+        with patch.object(
+            ZarrIODataChunkIteratorQueue,
+            "__write_chunk__",
+            wraps=ZarrIODataChunkIteratorQueue.__write_chunk__,
+        ) as sequential_write:
+            with pytest.warns(UserWarning, match="Writing dataset 'unsafe' sequentially"):
+                with ZarrIO(store, manager=get_manager(), mode="w") as io:
+                    io.write(table, number_of_jobs=2, multiprocessing_context="spawn")
+    assert executor.called
+    assert {call.args[0].path for call in sequential_write.call_args_list} == {"unsafe"}
+    group = zarr.open_group(store, mode="r")
+    for name in ("unsafe", "safe"):
+        assert_array_equal(group[name][:], data)
+
+
+def test_auto_shards_iterator(tmp_path):
+    """Use Zarr's resolved layout to decide whether automatic shards are safe."""
+
+    data = np.arange(1, 65, dtype="int32")
+    iterator = PickleableDataChunkIterator(data, chunk_shape=(2,), buffer_shape=(2,))
+    table = DynamicTable(
+        name="table",
+        description="",
+        id=list(range(len(data))),
+        columns=[VectorData(name="values", description="", data=ZarrDataIO(iterator, chunks=(2,), shards="auto"))],
+    )
+    store = str(tmp_path / "auto.zarr")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with patch("hdmf_zarr.utils.ProcessPoolExecutor", wraps=ProcessPoolExecutor) as executor:
+            with ZarrIO(store, manager=get_manager(), mode="w") as io:
+                io.write(table, number_of_jobs=2, multiprocessing_context="spawn")
+    array = zarr.open_group(store, mode="r")["values"]
+    assert array.shards is not None
+    assert executor.called == (array.shards == (2,))
+    fallback = [w for w in caught if "Writing dataset 'values' sequentially" in str(w.message)]
+    assert len(fallback) == (0 if executor.called else 1)
+    assert_array_equal(array[:], data)

--- a/tests/unit/test_parallel_write.py
+++ b/tests/unit/test_parallel_write.py
@@ -3,7 +3,6 @@
 import unittest
 from itertools import product
 import platform
-import warnings
 from concurrent.futures import ProcessPoolExecutor
 from typing import Tuple, Dict
 from io import StringIO
@@ -317,14 +316,10 @@ def test_sharded_iterator_write_routing(tmp_path, shape, chunks, shards, buffers
     column = VectorData(name="values", description="", data=ZarrDataIO(iterator, chunks=chunks, shards=shards))
     table = DynamicTable(name="table", description="", id=list(range(shape[0])), columns=[column])
     store = str(tmp_path / "data.zarr")
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        with patch("hdmf_zarr.utils.ProcessPoolExecutor", wraps=RecordingExecutor) as executor:
-            with ZarrIO(store, manager=get_manager(), mode="w") as io:
-                io.write(table, number_of_jobs=2, multiprocessing_context="spawn")
+    with patch("hdmf_zarr.utils.ProcessPoolExecutor", wraps=RecordingExecutor) as executor:
+        with ZarrIO(store, manager=get_manager(), mode="w") as io:
+            io.write(table, number_of_jobs=2, multiprocessing_context="spawn")
     assert executor.called
-    fallback_warnings = [w for w in caught if "Writing dataset 'values' sequentially" in str(w.message)]
-    assert not fallback_warnings
     array = zarr.open_group(store, mode="r")["values"]
     assert array.shards == shards
     assert_array_equal(array[:], data)
@@ -395,16 +390,12 @@ def test_auto_shards_iterator(tmp_path):
         columns=[VectorData(name="values", description="", data=ZarrDataIO(iterator, chunks=(2,), shards="auto"))],
     )
     store = str(tmp_path / "auto.zarr")
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        with patch("hdmf_zarr.utils.ProcessPoolExecutor", wraps=ProcessPoolExecutor) as executor:
-            with ZarrIO(store, manager=get_manager(), mode="w") as io:
-                io.write(table, number_of_jobs=2, multiprocessing_context="spawn")
+    with patch("hdmf_zarr.utils.ProcessPoolExecutor", wraps=ProcessPoolExecutor) as executor:
+        with ZarrIO(store, manager=get_manager(), mode="w") as io:
+            io.write(table, number_of_jobs=2, multiprocessing_context="spawn")
     array = zarr.open_group(store, mode="r")["values"]
     assert array.shards is not None
     assert executor.called
-    fallback = [w for w in caught if "Writing dataset 'values' sequentially" in str(w.message)]
-    assert not fallback
     assert_array_equal(array[:], data)
 
 

--- a/tests/unit/test_zarrdataio.py
+++ b/tests/unit/test_zarrdataio.py
@@ -141,6 +141,7 @@ class TestZarrDataIO(TestCase):
         )
         # test that we apply shuffle filter on int data
         from zarr.codecs.numcodecs import Shuffle as ZarrShuffle
+
         filters = ZarrDataIO.hdf5_to_zarr_filters(h5dset_int)
         self.assertEqual(len(filters), 1)
         self.assertIsInstance(filters[0], ZarrShuffle)
@@ -162,6 +163,7 @@ class TestZarrDataIO(TestCase):
         )
         # test that we apply blosc filter on data
         from zarr.codecs.numcodecs import Blosc as ZarrBlosc
+
         filters = ZarrDataIO.hdf5_to_zarr_filters(h5dset)
         self.assertEqual(len(filters), 1)
         self.assertIsInstance(filters[0], ZarrBlosc)
@@ -182,6 +184,7 @@ class TestZarrDataIO(TestCase):
         )
         # test that we apply zstd filter on data
         from zarr.codecs.numcodecs import Zstd as ZarrZstd
+
         filters = ZarrDataIO.hdf5_to_zarr_filters(h5dset)
         self.assertEqual(len(filters), 1)
         self.assertIsInstance(filters[0], ZarrZstd)
@@ -201,6 +204,7 @@ class TestZarrDataIO(TestCase):
         )
         # test that we apply gzip/zlib filter on data
         from zarr.codecs.numcodecs import Zlib as ZarrZlib
+
         filters = ZarrDataIO.hdf5_to_zarr_filters(h5dset)
         self.assertEqual(len(filters), 1)
         self.assertIsInstance(filters[0], ZarrZlib)
@@ -236,6 +240,7 @@ class TestZarrDataIO(TestCase):
         self.assertEqual(re_zarrdataio.chunks, (5, 10))
         # In zarr v3, compressors and filters are separated. Shuffle is a BytesBytesCodec (compressor).
         from zarr.codecs.numcodecs import Shuffle as ZarrShuffle, Zlib as ZarrZlib
+
         self.assertNotIn("filters", re_zarrdataio.io_settings)
         self.assertEqual(len(re_zarrdataio.io_settings["compressors"]), 2)
         self.assertIsInstance(re_zarrdataio.io_settings["compressors"][0], ZarrShuffle)
@@ -312,3 +317,12 @@ class TestZarrDataIOSharding(TestCase):
         data = np.arange(1000, dtype="i4").reshape(100, 10)
         with self.assertRaises(ValueError):
             ZarrDataIO(data, chunks=(10, 3), shards=(50, 10))
+
+    def test_auto_shards(self):
+        for chunks in (None, (2,)):
+            io = ZarrDataIO(np.arange(16), chunks=chunks, shards="auto")
+            self.assertEqual(io.io_settings["shards"], "auto")
+
+    def test_invalid_shards_string(self):
+        with self.assertRaisesRegex(ValueError, "'shards' must be a shape or 'auto'"):
+            ZarrDataIO(np.arange(16), shards="automatic")


### PR DESCRIPTION
[Edited after discussion]

When reviewing #372 I reproduced data loss from two workers updating different chunks in the same shard. After that, I found the same problem documented in [Zarr #3514](https://github.com/zarr-developers/zarr-python/issues/3514). [Dask addressed it by aligning its write tasks to shards](https://github.com/dask/dask/pull/12105). Before this change the parallel queue created one task per iterator buffer. Those buffers can overlap the same shard even when their array selections don't overlap. A partial update reads the existing encoded shard and writes its replacement, so one worker can overwrite the other worker's changes.

This PR prevents different workers from updating the same shard. A worker can be assigned to work with several complete shards, so an aligned buffer is still read and written in one assignment. Workers still operate in parallel but across different shards:

<img width="1440" height="740" alt="image" src="https://github.com/user-attachments/assets/4c0fc01c-4b7a-4350-ade5-372b552a116b" />

When buffers don't align with shards, one task owns each shard and processes its buffer pieces sequentially.

An important note: the implementation here is flexible and does not couple buffer shapes to shard shapes as those come from different concerns (storage layout in the destination vs reading patterns from the source). In practice though, **we should recommend buffers equal to the shard shape or an integer multiple along each axis**. The critical point is that a partial shard update reads the whole existing encoded shard into memory and assembles its replacement. As confirmed in [this maintainer reply](https://github.com/zarr-developers/zarr-python/issues/3604#issuecomment-3608753457), Zarr-Python has no API to defer writing a shard until all its chunks have been processed. I verified this behavior locally.

This means that we have two problems when the shard is larger than the buffer: 
1. The existing encoded shard and its replacement add memory beyond the source buffer. So `buffer_shape` doesn't bound total write memory, and a large shard can defeat the purpose of choosing a small buffer.
2. We repeatedly read and rewrite the data already stored in that shard as successive buffer pieces are written.

I have added documentation on this as I am unsure that python-zarr will change anytime soon and we can change it then.

I also added `shards="auto"` to `ZarrDataIO` and we pass it through.
